### PR TITLE
Add SF Parks Biodiversity map app

### DIFF
--- a/sf-parks-biodiversity/app.js
+++ b/sf-parks-biodiversity/app.js
@@ -1,0 +1,656 @@
+'use strict';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Config
+// ─────────────────────────────────────────────────────────────────────────────
+
+const INAT_API = 'https://api.inaturalist.org/v1';
+
+// SF Open Data – Recreation & Park Properties (polygon geometries)
+// Dataset: https://data.sfgov.org/Recreation-and-Parks/Recreation-and-Park-Department-Park-Info/z76i-7yes
+const SF_PARKS_URL =
+  'https://data.sfgov.org/resource/z76i-7yes.geojson?$limit=500';
+
+// Fallback: broader open spaces dataset
+const SF_OPENSPACES_URL =
+  'https://data.sfgov.org/resource/5fh8-fiqg.geojson?$limit=500';
+
+const CATEGORIES = [
+  { key: 'Plantae',   label: 'Plants',      icon: '🌿', col: '#4a8c4a' },
+  { key: 'Aves',      label: 'Birds',       icon: '🐦', col: '#4a7aad' },
+  { key: 'Insecta',   label: 'Insects',     icon: '🦋', col: '#c9a227' },
+  { key: 'Mammalia',  label: 'Mammals',     icon: '🦊', col: '#a07040' },
+  { key: 'Fungi',     label: 'Fungi',       icon: '🍄', col: '#8b5e3c' },
+  { key: 'Reptilia',  label: 'Reptiles',    icon: '🦎', col: '#5a7a3a' },
+  { key: 'Amphibia',  label: 'Amphibians',  icon: '🐸', col: '#3a7a5a' },
+  { key: 'Arachnida', label: 'Arachnids',   icon: '🕷️', col: '#6a3a6a' },
+  { key: 'Mollusca',  label: 'Mollusks',    icon: '🐌', col: '#7a5a3a' },
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// State
+// ─────────────────────────────────────────────────────────────────────────────
+
+const state = {
+  parks: [],                  // GeoJSON features
+  sfPlaceId: null,            // iNaturalist place_id for SF County
+  selectedId: null,           // currently-selected park ID
+  countCache: {},             // id → total species count (from quick query)
+  detailCache: {},            // id → { species[], cats{}, nativeCount, introducedCount }
+  rankings: {},               // id → { name, total, cats{}, nativeCount, feature }
+  sortCol: 'total',
+  loadingAll: false,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Map
+// ─────────────────────────────────────────────────────────────────────────────
+
+let map;
+let parksLayer;
+
+function initMap() {
+  map = L.map('map', { center: [37.7599, -122.44], zoom: 12, zoomControl: true });
+
+  L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
+    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/">CARTO</a>',
+    subdomains: 'abcd',
+    maxZoom: 20,
+  }).addTo(map);
+}
+
+const PARK_STYLE = {
+  default:  { fillColor: '#2a4a2a', fillOpacity: 0.30, color: '#4a7a4a', weight: 1 },
+  hover:    { fillColor: '#3a6a3a', fillOpacity: 0.50, color: '#7ab07a', weight: 2 },
+  selected: { fillColor: '#5a9b5a', fillOpacity: 0.55, color: '#a0cf9f', weight: 2 },
+};
+
+function parkId(feature) {
+  const p = feature.properties || {};
+  return (
+    p.rec_park_id || p.parkid || p.park_id || p.object_id || p.objectid ||
+    p.map_label || p.common_nm || p.name || p.park_name ||
+    JSON.stringify(feature.geometry?.coordinates?.[0]?.[0])
+  );
+}
+
+function parkName(feature) {
+  const p = feature.properties || {};
+  return (
+    p.common_nm || p.name || p.park_name || p.parkname ||
+    p.rec_park_nm || p.map_label || 'Unnamed Park'
+  );
+}
+
+function parkBounds(feature) {
+  const b = L.geoJSON(feature).getBounds();
+  return { swlat: b.getSouth(), swlng: b.getWest(), nelat: b.getNorth(), nelng: b.getEast() };
+}
+
+function addParksToMap(features) {
+  if (parksLayer) parksLayer.remove();
+
+  parksLayer = L.geoJSON({ type: 'FeatureCollection', features }, {
+    style: () => ({ ...PARK_STYLE.default }),
+    onEachFeature(feature, layer) {
+      const name = parkName(feature);
+      const id   = parkId(feature);
+
+      layer.on('mouseover', () => {
+        if (state.selectedId !== id) layer.setStyle(PARK_STYLE.hover);
+        layer.bindTooltip(esc(name), {
+          permanent: false,
+          className: 'park-tooltip',
+          direction: 'top',
+          offset: [0, -4],
+        }).openTooltip();
+      });
+
+      layer.on('mouseout', () => {
+        if (state.selectedId !== id) layer.setStyle(PARK_STYLE.default);
+      });
+
+      layer.on('click', (e) => {
+        L.DomEvent.stopPropagation(e);
+        selectPark(feature, layer);
+      });
+    },
+  }).addTo(map);
+
+  // Deselect on bare map click
+  map.on('click', closeSidebar);
+}
+
+function resetAllStyles() {
+  if (!parksLayer) return;
+  parksLayer.eachLayer((layer) => {
+    const id = layer.feature ? parkId(layer.feature) : null;
+    layer.setStyle(id && id === state.selectedId ? PARK_STYLE.selected : PARK_STYLE.default);
+  });
+}
+
+function selectPark(feature, layer) {
+  state.selectedId = parkId(feature);
+  resetAllStyles();
+  layer.setStyle(PARK_STYLE.selected);
+  openSidebar(feature);
+
+  // Highlight matching ranking row
+  document.querySelectorAll('#rankings-body tr').forEach((r) => {
+    r.classList.toggle('row-selected', r.dataset.pid === state.selectedId);
+  });
+}
+
+function findLayerByFeature(feature) {
+  let found = null;
+  parksLayer?.eachLayer((l) => {
+    if (parkId(l.feature) === parkId(feature)) found = l;
+  });
+  return found;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// iNaturalist API
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function apiFetch(url) {
+  for (let attempt = 0; attempt < 4; attempt++) {
+    const resp = await fetch(url);
+    if (resp.status === 429) {
+      await sleep(1200 * (attempt + 1));
+      continue;
+    }
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}: ${url}`);
+    return resp.json();
+  }
+  throw new Error('Rate-limited after retries');
+}
+
+function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+async function findSFPlaceId() {
+  try {
+    const d = await apiFetch(`${INAT_API}/places/autocomplete?q=San+Francisco&per_page=10`);
+    const place = (d.results || []).find(
+      p => p.name === 'San Francisco County' ||
+           (p.name === 'San Francisco' && p.place_type_name === 'County')
+    ) || (d.results || []).find(p => p.name === 'San Francisco');
+    return place?.id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function buildParams(bounds, extra = {}) {
+  const p = new URLSearchParams({
+    swlat: bounds.swlat, swlng: bounds.swlng,
+    nelat: bounds.nelat, nelng: bounds.nelng,
+    quality_grade: 'research',
+  });
+  if (state.sfPlaceId) p.set('place_id', state.sfPlaceId);
+  for (const [k, v] of Object.entries(extra)) p.set(k, v);
+  return p;
+}
+
+/** Quick count only – used for bulk rankings loading */
+async function fetchCount(feature) {
+  const id = parkId(feature);
+  if (state.countCache[id] !== undefined) return state.countCache[id];
+
+  const params = buildParams(parkBounds(feature), { per_page: 1 });
+  const d = await apiFetch(`${INAT_API}/observations/species_counts?${params}`);
+  const count = d.total_results ?? 0;
+  state.countCache[id] = count;
+  return count;
+}
+
+/** Full species detail – used when a park is clicked */
+async function fetchDetail(feature) {
+  const id = parkId(feature);
+  if (state.detailCache[id]) return state.detailCache[id];
+
+  const bounds = parkBounds(feature);
+  const base = buildParams(bounds, { per_page: 200, order_by: 'count', order: 'desc' });
+  const first = await apiFetch(`${INAT_API}/observations/species_counts?${base}`);
+
+  let all = first.results || [];
+  const total = first.total_results || 0;
+  const pages = Math.min(Math.ceil(total / 200), 5); // cap at 1 000 species
+
+  if (pages > 1) {
+    const more = await Promise.all(
+      Array.from({ length: pages - 1 }, (_, i) => {
+        const p = new URLSearchParams(base);
+        p.set('page', i + 2);
+        return apiFetch(`${INAT_API}/observations/species_counts?${p}`);
+      })
+    );
+    for (const r of more) all = all.concat(r.results || []);
+  }
+
+  const cats = {};
+  CATEGORIES.forEach(c => { cats[c.key] = 0; });
+  let nativeCount = 0, introducedCount = 0;
+
+  for (const s of all) {
+    const k = s.taxon?.iconic_taxon_name;
+    if (k && cats.hasOwnProperty(k)) cats[k]++;
+
+    const em = establishmentMeans(s);
+    if (em === 'native' || em === 'endemic') nativeCount++;
+    else if (em === 'introduced' || em === 'naturalizing') introducedCount++;
+  }
+
+  const detail = { species: all, cats, nativeCount, introducedCount };
+  state.detailCache[id] = detail;
+  return detail;
+}
+
+function establishmentMeans(s) {
+  return (
+    s.taxon?.establishment_means?.establishment_means ||
+    s.taxon?.listed_taxon?.establishment_means ||
+    null
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sidebar
+// ─────────────────────────────────────────────────────────────────────────────
+
+function openSidebar(feature) {
+  const sidebar = document.getElementById('sidebar');
+  sidebar.classList.remove('sidebar-closed');
+
+  const name = parkName(feature);
+  const content = document.getElementById('sidebar-content');
+  content.innerHTML = `
+    <div class="park-header">
+      <div class="park-title">${esc(name)}</div>
+      <div class="park-meta">Fetching iNaturalist data…</div>
+    </div>
+    <div class="loading-block">
+      <div class="spinner"></div>
+      <span>Loading species…</span>
+    </div>`;
+
+  currentEM = 'all'; // reset filter state for each new park open
+
+  fetchDetail(feature)
+    .then(detail => {
+      renderSidebar(feature, detail);
+      updateRankingFromDetail(feature, detail);
+    })
+    .catch(err => {
+      content.innerHTML = `
+        <div class="park-header"><div class="park-title">${esc(name)}</div></div>
+        <div class="error-block">Failed to load: ${esc(err.message)}</div>`;
+    });
+}
+
+function closeSidebar() {
+  document.getElementById('sidebar').classList.add('sidebar-closed');
+  state.selectedId = null;
+  resetAllStyles();
+  document.querySelectorAll('#rankings-body tr').forEach(r => r.classList.remove('row-selected'));
+}
+
+function renderSidebar(feature, detail) {
+  const name = parkName(feature);
+  const { species, cats, nativeCount, introducedCount } = detail;
+  const total = species.length;
+  const nativePct = total > 0 ? Math.round((nativeCount / total) * 100) : '–';
+
+  // Category grid
+  const catHTML = CATEGORIES.map(c => `
+    <div class="cat-pill" data-cat="${c.key}">
+      <span class="p-icon">${c.icon}</span>
+      <span class="p-count">${cats[c.key] || 0}</span>
+      <span class="p-label">${c.label}</span>
+    </div>`).join('');
+
+  document.getElementById('sidebar-content').innerHTML = `
+    <div class="park-header">
+      <div class="park-title">${esc(name)}</div>
+      <div class="park-meta">${total.toLocaleString()} species · ${nativePct}% native/endemic · research grade</div>
+    </div>
+    <div class="cat-grid">${catHTML}</div>
+    <div id="em-filter">
+      <button class="em-btn active" data-em="all">All (${total})</button>
+      <button class="em-btn" data-em="native">Native (${nativeCount})</button>
+      <button class="em-btn" data-em="introduced">Introduced (${introducedCount})</button>
+    </div>
+    <div id="sp-list-wrap">${buildSpeciesHTML(species, 'all', null)}</div>`;
+
+  // Category pill filtering
+  let activeCat = null;
+  document.querySelectorAll('.cat-pill').forEach(pill => {
+    pill.addEventListener('click', () => {
+      const cat = pill.dataset.cat;
+      activeCat = (activeCat === cat) ? null : cat;
+      document.querySelectorAll('.cat-pill').forEach(p => p.classList.toggle('active', p.dataset.cat === activeCat));
+      refreshSpeciesList(species, activeCat);
+    });
+  });
+
+  // EM filter buttons
+  document.querySelectorAll('.em-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('.em-btn').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      // reset cat
+      activeCat = null;
+      document.querySelectorAll('.cat-pill').forEach(p => p.classList.remove('active'));
+      refreshSpeciesList(species, null, btn.dataset.em);
+    });
+  });
+}
+
+let currentEM = 'all';
+function refreshSpeciesList(species, cat, em) {
+  if (em != null) currentEM = em;
+  document.getElementById('sp-list-wrap').innerHTML = buildSpeciesHTML(species, currentEM, cat ?? null);
+}
+
+function buildSpeciesHTML(species, em = 'all', cat = null) {
+  let list = species;
+
+  if (cat) list = list.filter(s => s.taxon?.iconic_taxon_name === cat);
+
+  if (em === 'native')
+    list = list.filter(s => { const e = establishmentMeans(s); return e === 'native' || e === 'endemic'; });
+  else if (em === 'introduced')
+    list = list.filter(s => { const e = establishmentMeans(s); return e === 'introduced' || e === 'naturalizing'; });
+
+  if (list.length === 0)
+    return '<div style="color:#2a5a2a;font-size:0.74rem;padding:10px 4px;font-style:italic">No species match this filter.</div>';
+
+  const SHOW = 300;
+  const items = list.slice(0, SHOW).map(speciesItemHTML).join('');
+  const overflow = list.length > SHOW
+    ? `<div class="list-overflow">Showing ${SHOW} of ${list.length.toLocaleString()} species</div>`
+    : '';
+  return `<div class="species-list">${items}</div>${overflow}`;
+}
+
+function speciesItemHTML(s) {
+  const t = s.taxon || {};
+  const common = t.preferred_common_name || t.name || 'Unknown';
+  const sci    = t.name || '';
+  const cat    = CATEGORIES.find(c => c.key === t.iconic_taxon_name);
+  const em     = establishmentMeans(s);
+
+  const photoUrl = t.default_photo?.square_url;
+  const photoEl = photoUrl
+    ? `<img class="sp-photo" src="${esc(photoUrl)}" alt="${esc(common)}" loading="lazy">`
+    : `<div class="sp-no-photo">${cat?.icon ?? '🔬'}</div>`;
+
+  const emBadge =
+    em === 'native'       ? '<span class="badge badge-native">native</span>' :
+    em === 'endemic'      ? '<span class="badge badge-endemic">endemic</span>' :
+    em === 'introduced'   ? '<span class="badge badge-introduced">introduced</span>' :
+    em === 'naturalizing' ? '<span class="badge badge-naturalizing">naturalizing</span>' : '';
+
+  const catBadge = cat ? `<span class="badge badge-cat">${cat.icon} ${cat.label}</span>` : '';
+  const obsLabel = `${s.count.toLocaleString()} obs`;
+
+  return `
+    <div class="sp-item">
+      ${photoEl}
+      <div class="sp-info">
+        <div class="sp-common">${esc(common)}</div>
+        <div class="sp-sci">${esc(sci)}</div>
+        <div class="sp-badges">${catBadge}${emBadge}</div>
+        <div class="sp-obs">${obsLabel}</div>
+      </div>
+    </div>`;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Rankings
+// ─────────────────────────────────────────────────────────────────────────────
+
+function updateRankingFromDetail(feature, detail) {
+  const id = parkId(feature);
+  state.rankings[id] = {
+    name:    parkName(feature),
+    total:   detail.species.length,
+    cats:    detail.cats,
+    nativeCount: detail.nativeCount,
+    feature,
+  };
+  renderRankings();
+  document.getElementById('stat-ranked').textContent = Object.keys(state.rankings).length;
+}
+
+function updateRankingFromCount(feature, count) {
+  const id = parkId(feature);
+  if (state.rankings[id]) return; // already have detail
+  state.rankings[id] = {
+    name:    parkName(feature),
+    total:   count,
+    cats:    null, // will be filled when clicked
+    nativeCount: null,
+    feature,
+  };
+  renderRankings();
+  document.getElementById('stat-ranked').textContent = Object.keys(state.rankings).length;
+}
+
+function sortedRankings() {
+  const entries = Object.values(state.rankings);
+  const col = state.sortCol;
+
+  return entries.sort((a, b) => {
+    if (col === 'native_pct') {
+      const ap = a.nativeCount != null && a.total > 0 ? a.nativeCount / a.total : -1;
+      const bp = b.nativeCount != null && b.total > 0 ? b.nativeCount / b.total : -1;
+      return bp - ap;
+    }
+    if (col === 'total') return (b.total ?? 0) - (a.total ?? 0);
+    return ((b.cats?.[col] ?? 0) - (a.cats?.[col] ?? 0));
+  });
+}
+
+function renderRankings() {
+  const body = document.getElementById('rankings-body');
+  const sorted = sortedRankings();
+
+  if (sorted.length === 0) {
+    body.innerHTML = `<tr><td colspan="9" class="empty-msg">
+      Click a park on the map, or press <strong>Load all parks</strong> to build the full ranking.
+    </td></tr>`;
+    return;
+  }
+
+  body.innerHTML = sorted.map((entry, i) => {
+    const id  = parkId(entry.feature);
+    const sel = state.selectedId === id ? 'row-selected' : '';
+    const nativePct = entry.nativeCount != null && entry.total > 0
+      ? Math.round((entry.nativeCount / entry.total) * 100) + '%'
+      : entry.total != null ? '–' : '<span class="td-loading">…</span>';
+
+    const numOrDash = (v) =>
+      v != null ? v.toLocaleString() : '<span class="td-loading">…</span>';
+
+    const other = entry.cats
+      ? Math.max(0, entry.total -
+          CATEGORIES.filter(c => ['Plantae','Aves','Insecta','Mammalia','Fungi'].includes(c.key))
+            .reduce((s, c) => s + (entry.cats[c.key] || 0), 0))
+      : null;
+
+    return `<tr class="${sel}" data-pid="${esc(id)}">
+      <td class="td-rank">${i + 1}</td>
+      <td class="td-name" title="${esc(entry.name)}">${esc(entry.name)}</td>
+      <td class="td-num">${numOrDash(entry.total)}</td>
+      <td class="td-num">${numOrDash(entry.cats?.Plantae)}</td>
+      <td class="td-num">${numOrDash(entry.cats?.Aves)}</td>
+      <td class="td-num">${numOrDash(entry.cats?.Insecta)}</td>
+      <td class="td-num">${numOrDash(entry.cats?.Mammalia)}</td>
+      <td class="td-num">${numOrDash(entry.cats?.Fungi)}</td>
+      <td class="td-num">${nativePct}</td>
+    </tr>`;
+  }).join('');
+
+  // Row click → select park on map
+  body.querySelectorAll('tr[data-pid]').forEach(row => {
+    row.addEventListener('click', () => {
+      const entry = state.rankings[row.dataset.pid];
+      if (!entry?.feature) return;
+
+      const layer = findLayerByFeature(entry.feature);
+      if (layer) {
+        map.fitBounds(layer.getBounds(), { padding: [50, 50], maxZoom: 16 });
+        selectPark(entry.feature, layer);
+      }
+    });
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Load-all-parks workflow
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function loadAllParks() {
+  if (state.loadingAll) return;
+  state.loadingAll = true;
+
+  const btn  = document.getElementById('load-all-btn');
+  const prog = document.getElementById('rank-progress');
+  const fill = document.getElementById('rank-progress-fill');
+  const lbl  = document.getElementById('rank-progress-label');
+
+  btn.disabled = true;
+  prog.classList.remove('hidden');
+
+  const parks = state.parks.filter(f => f.geometry);
+  const total = parks.length;
+  let done = 0;
+
+  // Process with limited concurrency so we respect iNaturalist rate limits
+  const CONCURRENCY = 3;
+  const queue = [...parks];
+
+  async function worker() {
+    while (queue.length > 0) {
+      const feature = queue.shift();
+      try {
+        const count = await fetchCount(feature);
+        updateRankingFromCount(feature, count);
+      } catch {
+        /* skip failed parks */
+      }
+      done++;
+      const pct = Math.round((done / total) * 100);
+      fill.style.width = pct + '%';
+      lbl.textContent  = `${done} / ${total}`;
+    }
+  }
+
+  await Promise.all(Array.from({ length: CONCURRENCY }, worker));
+
+  state.loadingAll = false;
+  btn.disabled     = false;
+  btn.textContent  = 'Reload';
+  prog.classList.add('hidden');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Parks data loading
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function tryFetchParks(url) {
+  const resp = await fetch(url);
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  const data = await resp.json();
+
+  // Socrata GeoJSON returns a FeatureCollection directly
+  const features = (data.features || []).filter(
+    f => f.geometry &&
+         (f.geometry.type === 'Polygon' || f.geometry.type === 'MultiPolygon')
+  );
+
+  if (features.length === 0) throw new Error('No polygon features found');
+  return features;
+}
+
+async function loadParks() {
+  showMapOverlay('Loading SF parks…');
+
+  let features;
+  try {
+    features = await tryFetchParks(SF_PARKS_URL);
+  } catch (e1) {
+    try {
+      features = await tryFetchParks(SF_OPENSPACES_URL);
+    } catch (e2) {
+      showMapOverlay(`Failed to load parks data.\n${e1.message}\n${e2.message}`, true);
+      return;
+    }
+  }
+
+  state.parks = features;
+  addParksToMap(features);
+  hideMapOverlay();
+  document.getElementById('stat-parks').textContent = features.length;
+}
+
+function showMapOverlay(text, isError = false) {
+  const el = document.getElementById('map-overlay-msg');
+  el.classList.remove('hidden');
+  el.innerHTML = isError
+    ? `<span style="color:#cf9f9f">${esc(text)}</span>`
+    : `<div class="spinner"></div><span>${esc(text)}</span>`;
+}
+
+function hideMapOverlay() {
+  document.getElementById('map-overlay-msg').classList.add('hidden');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Utilities
+// ─────────────────────────────────────────────────────────────────────────────
+
+function esc(str) {
+  return String(str ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Init
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function init() {
+  initMap();
+
+  // Kick off SF place-ID lookup in parallel with parks load
+  findSFPlaceId().then(id => { state.sfPlaceId = id; });
+
+  await loadParks();
+
+  // Sidebar close
+  document.getElementById('sidebar-close').addEventListener('click', closeSidebar);
+
+  // Load-all button
+  document.getElementById('load-all-btn').addEventListener('click', loadAllParks);
+
+  // Sort buttons (bar)
+  document.querySelectorAll('.sort-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('.sort-btn').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      state.sortCol = btn.dataset.col;
+      renderRankings();
+    });
+  });
+
+  // Table header clicks also sort
+  document.querySelectorAll('#rankings-table thead th.sortable').forEach(th => {
+    th.addEventListener('click', () => {
+      state.sortCol = th.dataset.col;
+      document.querySelectorAll('.sort-btn').forEach(b => b.classList.toggle('active', b.dataset.col === state.sortCol));
+      renderRankings();
+    });
+  });
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/sf-parks-biodiversity/index.html
+++ b/sf-parks-biodiversity/index.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SF Parks Biodiversity</title>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
+  <link rel="stylesheet" href="style.css"/>
+</head>
+<body>
+  <div id="app">
+
+    <header id="header">
+      <div id="header-left">
+        <h1>SF Parks Biodiversity</h1>
+        <div class="subtitle">iNaturalist research-grade species · Click any park to explore</div>
+      </div>
+      <div id="header-stats">
+        <div class="stat">
+          <span id="stat-parks">–</span>
+          <label>parks</label>
+        </div>
+        <div class="stat">
+          <span id="stat-ranked">0</span>
+          <label>ranked</label>
+        </div>
+      </div>
+    </header>
+
+    <div id="body-wrap">
+
+      <!-- Map + sliding sidebar -->
+      <div id="map-panel">
+        <div id="map"></div>
+
+        <div id="map-overlay-msg" class="hidden">
+          <div class="spinner"></div>
+          <span id="map-overlay-text">Loading parks…</span>
+        </div>
+
+        <div id="sidebar" class="sidebar-closed">
+          <button id="sidebar-close" title="Close">✕</button>
+          <div id="sidebar-scroll">
+            <div id="sidebar-content"></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Rankings -->
+      <div id="rankings-panel">
+        <div id="rankings-bar">
+          <h2>Biodiversity Rankings</h2>
+
+          <div id="rankings-actions">
+            <button id="load-all-btn">Load all parks</button>
+            <div id="rank-progress" class="hidden">
+              <div id="rank-progress-track"><div id="rank-progress-fill"></div></div>
+              <span id="rank-progress-label"></span>
+            </div>
+          </div>
+
+          <div id="sort-row">
+            <span class="sort-label">Sort:</span>
+            <button class="sort-btn active" data-col="total">Total</button>
+            <button class="sort-btn" data-col="Plantae">Plants</button>
+            <button class="sort-btn" data-col="Aves">Birds</button>
+            <button class="sort-btn" data-col="Insecta">Insects</button>
+            <button class="sort-btn" data-col="Mammalia">Mammals</button>
+            <button class="sort-btn" data-col="native_pct">% Native</button>
+          </div>
+        </div>
+
+        <div id="rankings-scroll">
+          <table id="rankings-table">
+            <thead>
+              <tr>
+                <th class="th-rank">#</th>
+                <th class="th-name">Park / Natural Area</th>
+                <th class="th-num sortable" data-col="total">Species</th>
+                <th class="th-num sortable" data-col="Plantae">🌿 Plants</th>
+                <th class="th-num sortable" data-col="Aves">🐦 Birds</th>
+                <th class="th-num sortable" data-col="Insecta">🦋 Insects</th>
+                <th class="th-num sortable" data-col="Mammalia">🦊 Mammals</th>
+                <th class="th-num sortable" data-col="Fungi">🍄 Fungi</th>
+                <th class="th-num sortable" data-col="native_pct">Native %</th>
+              </tr>
+            </thead>
+            <tbody id="rankings-body">
+              <tr>
+                <td colspan="9" class="empty-msg">
+                  Click a park on the map, or press <strong>Load all parks</strong> to build the full ranking.
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+    </div><!-- /body-wrap -->
+  </div><!-- /app -->
+
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/sf-parks-biodiversity/style.css
+++ b/sf-parks-biodiversity/style.css
@@ -1,0 +1,609 @@
+/* ─── Reset & base ─────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html, body {
+  height: 100%;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background: #111d11;
+  color: #cde0cd;
+  overflow: hidden;
+}
+
+#app {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  height: 100dvh;
+}
+
+/* ─── Header ────────────────────────────────────── */
+#header {
+  flex: 0 0 auto;
+  background: #0a150a;
+  border-bottom: 1px solid #243824;
+  padding: 9px 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+#header h1 {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #9fcf9f;
+  line-height: 1.2;
+}
+
+.subtitle {
+  font-size: 0.67rem;
+  color: #3a603a;
+  margin-top: 2px;
+}
+
+#header-stats {
+  display: flex;
+  gap: 18px;
+  flex-shrink: 0;
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 36px;
+}
+
+.stat span {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #5a9b5a;
+  line-height: 1;
+}
+
+.stat label {
+  font-size: 0.6rem;
+  color: #3a603a;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-top: 2px;
+}
+
+/* ─── Body layout ───────────────────────────────── */
+#body-wrap {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-height: 0;
+}
+
+/* ─── Map panel ─────────────────────────────────── */
+#map-panel {
+  position: relative;
+  flex: 0 0 56%;
+  min-height: 0;
+}
+
+#map {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+}
+
+/* Map overlay (loading / error) */
+#map-overlay-msg {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 500;
+  background: rgba(10,21,10,0.92);
+  border: 1px solid #2a402a;
+  border-radius: 10px;
+  padding: 14px 20px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  pointer-events: none;
+}
+
+#map-overlay-msg.hidden { display: none; }
+
+#map-overlay-msg span {
+  font-size: 0.78rem;
+  color: #9fcf9f;
+}
+
+/* ─── Sidebar ───────────────────────────────────── */
+#sidebar {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 360px;
+  z-index: 400;
+  background: #0a150a;
+  border-left: 1px solid #243824;
+  display: flex;
+  flex-direction: column;
+  transform: translateX(0);
+  transition: transform 0.28s ease;
+  box-shadow: -6px 0 24px rgba(0,0,0,0.5);
+}
+
+#sidebar.sidebar-closed {
+  transform: translateX(100%);
+  pointer-events: none;
+}
+
+#sidebar-close {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 10;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  border: 1px solid #2a402a;
+  background: #162916;
+  color: #7ab07a;
+  font-size: 0.8rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s, color 0.15s;
+}
+
+#sidebar-close:hover {
+  background: #243824;
+  color: #cde0cd;
+}
+
+#sidebar-scroll {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 12px;
+}
+
+/* scrollbar */
+#sidebar-scroll::-webkit-scrollbar { width: 4px; }
+#sidebar-scroll::-webkit-scrollbar-track { background: #0a150a; }
+#sidebar-scroll::-webkit-scrollbar-thumb { background: #2a402a; border-radius: 2px; }
+
+/* ─── Park header in sidebar ────────────────────── */
+.park-header {
+  padding-bottom: 11px;
+  margin-bottom: 11px;
+  border-bottom: 1px solid #1e301e;
+}
+
+.park-title {
+  font-size: 0.98rem;
+  font-weight: 700;
+  color: #9fcf9f;
+  line-height: 1.3;
+  padding-right: 28px;
+}
+
+.park-meta {
+  font-size: 0.68rem;
+  color: #3a703a;
+  margin-top: 3px;
+}
+
+/* ─── Category grid ─────────────────────────────── */
+.cat-grid {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 5px;
+  margin-bottom: 12px;
+}
+
+.cat-pill {
+  background: #162916;
+  border: 1px solid #2a402a;
+  border-radius: 8px;
+  padding: 6px 3px 5px;
+  text-align: center;
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s;
+  user-select: none;
+}
+
+.cat-pill:hover { background: #1e321e; }
+
+.cat-pill.active {
+  border-color: #5a9b5a;
+  background: #1a301a;
+}
+
+.cat-pill .p-icon { font-size: 1rem; display: block; }
+.cat-pill .p-count { font-size: 0.82rem; font-weight: 700; color: #cde0cd; display: block; margin-top: 1px; }
+.cat-pill .p-label { font-size: 0.56rem; color: #5a9b5a; text-transform: uppercase; letter-spacing: 0.04em; display: block; }
+
+/* ─── Native filter row ─────────────────────────── */
+#em-filter {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 10px;
+  flex-wrap: wrap;
+}
+
+.em-btn {
+  padding: 3px 9px;
+  border-radius: 10px;
+  border: 1px solid #2a402a;
+  background: #162916;
+  color: #7ab07a;
+  font-size: 0.68rem;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+  white-space: nowrap;
+}
+
+.em-btn.active {
+  background: #243824;
+  border-color: #4a8a4a;
+  color: #cde0cd;
+}
+
+/* ─── Species list ──────────────────────────────── */
+.species-list {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.sp-item {
+  display: flex;
+  gap: 8px;
+  background: #162916;
+  border: 1px solid #1e301e;
+  border-radius: 8px;
+  padding: 7px;
+  transition: border-color 0.12s;
+}
+
+.sp-item:hover { border-color: #3a5a3a; }
+
+.sp-photo, .sp-no-photo {
+  width: 50px;
+  height: 50px;
+  border-radius: 6px;
+  flex-shrink: 0;
+  object-fit: cover;
+}
+
+.sp-no-photo {
+  background: #0e1e0e;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.25rem;
+}
+
+.sp-info { flex: 1; min-width: 0; }
+
+.sp-common {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #cde0cd;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sp-sci {
+  font-size: 0.66rem;
+  color: #5a9b5a;
+  font-style: italic;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sp-badges {
+  display: flex;
+  gap: 4px;
+  margin-top: 3px;
+  flex-wrap: wrap;
+}
+
+.badge {
+  font-size: 0.58rem;
+  padding: 1px 6px;
+  border-radius: 8px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.badge-native   { background: #162a16; color: #7acf7a; border: 1px solid #2a5a2a; }
+.badge-endemic  { background: #161a2a; color: #7ab0da; border: 1px solid #2a405a; }
+.badge-introduced { background: #2a1c12; color: #c09060; border: 1px solid #5a3820; }
+.badge-naturalizing { background: #2a2010; color: #c0a060; border: 1px solid #5a4820; }
+.badge-cat { background: #1a2a1a; color: #9fcf9f; border: 1px solid #2a4a2a; }
+
+.sp-obs {
+  font-size: 0.62rem;
+  color: #3a603a;
+  margin-top: 2px;
+}
+
+/* overflow notice */
+.list-overflow {
+  font-size: 0.68rem;
+  color: #3a603a;
+  font-style: italic;
+  padding: 8px 4px;
+}
+
+/* ─── Spinner / loading ─────────────────────────── */
+.spinner {
+  width: 22px;
+  height: 22px;
+  border: 2.5px solid #243824;
+  border-top-color: #5a9b5a;
+  border-radius: 50%;
+  animation: spin 0.75s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.loading-block {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 32px 0;
+}
+
+.loading-block .spinner { width: 28px; height: 28px; }
+.loading-block span { font-size: 0.75rem; color: #5a9b5a; }
+
+.error-block {
+  padding: 12px;
+  background: #2a1212;
+  border: 1px solid #5a2424;
+  border-radius: 8px;
+  color: #cf9f9f;
+  font-size: 0.76rem;
+  line-height: 1.5;
+}
+
+/* ─── Rankings panel ────────────────────────────── */
+#rankings-panel {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  border-top: 1px solid #1e301e;
+  background: #0c170c;
+}
+
+#rankings-bar {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 14px;
+  border-bottom: 1px solid #1e301e;
+  flex-wrap: wrap;
+}
+
+#rankings-bar h2 {
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: #9fcf9f;
+  margin-right: 2px;
+}
+
+#rankings-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+#load-all-btn {
+  padding: 4px 11px;
+  background: #162916;
+  border: 1px solid #2a402a;
+  color: #7ab07a;
+  border-radius: 12px;
+  font-size: 0.7rem;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+
+#load-all-btn:hover:not(:disabled) {
+  background: #243824;
+  color: #cde0cd;
+}
+
+#load-all-btn:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+#rank-progress {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+#rank-progress.hidden { display: none; }
+
+#rank-progress-track {
+  width: 90px;
+  height: 4px;
+  background: #1e301e;
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+#rank-progress-fill {
+  height: 100%;
+  background: #5a9b5a;
+  width: 0%;
+  transition: width 0.2s;
+}
+
+#rank-progress-label {
+  font-size: 0.65rem;
+  color: #5a9b5a;
+  white-space: nowrap;
+}
+
+#sort-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: auto;
+  flex-wrap: wrap;
+}
+
+.sort-label {
+  font-size: 0.65rem;
+  color: #3a603a;
+  margin-right: 2px;
+}
+
+.sort-btn {
+  padding: 3px 8px;
+  background: #162916;
+  border: 1px solid #2a402a;
+  color: #7ab07a;
+  border-radius: 10px;
+  font-size: 0.66rem;
+  cursor: pointer;
+  transition: background 0.12s;
+}
+
+.sort-btn.active {
+  background: #243824;
+  border-color: #4a8a4a;
+  color: #cde0cd;
+}
+
+/* ─── Rankings table ────────────────────────────── */
+#rankings-scroll {
+  flex: 1;
+  overflow: auto;
+}
+
+#rankings-scroll::-webkit-scrollbar { height: 4px; width: 4px; }
+#rankings-scroll::-webkit-scrollbar-track { background: #0c170c; }
+#rankings-scroll::-webkit-scrollbar-thumb { background: #2a402a; border-radius: 2px; }
+
+#rankings-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.76rem;
+}
+
+#rankings-table thead th {
+  position: sticky;
+  top: 0;
+  background: #0c170c;
+  padding: 7px 10px;
+  text-align: left;
+  color: #4a8a4a;
+  font-size: 0.64rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-bottom: 1px solid #1e301e;
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+}
+
+#rankings-table thead th:hover { color: #9fcf9f; }
+#rankings-table thead th.th-rank { width: 34px; }
+#rankings-table thead th.th-name { min-width: 160px; }
+#rankings-table thead th.th-num { width: 72px; text-align: right; }
+
+#rankings-table tbody td {
+  padding: 5px 10px;
+  border-bottom: 1px solid #111d11;
+  color: #cde0cd;
+  white-space: nowrap;
+}
+
+.td-num { text-align: right; }
+
+#rankings-table tbody tr {
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+#rankings-table tbody tr:hover { background: #162916; }
+#rankings-table tbody tr.row-selected { background: #1a2f1a; }
+
+.td-rank { color: #4a8a4a; font-weight: 700; }
+
+.td-name {
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #a0d0a0;
+  font-weight: 500;
+}
+
+.td-loading { color: #2a4a2a; font-style: italic; }
+
+.empty-msg {
+  padding: 20px 12px !important;
+  color: #2a5a2a;
+  font-style: italic;
+  font-size: 0.76rem;
+  text-align: center;
+}
+
+.empty-msg strong { color: #4a8a4a; }
+
+/* ─── Leaflet overrides ─────────────────────────── */
+.leaflet-popup-content-wrapper {
+  background: #0a150a;
+  color: #cde0cd;
+  border: 1px solid #2a402a;
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.5);
+}
+
+.leaflet-popup-tip { background: #0a150a; }
+
+.park-tooltip {
+  background: rgba(10,21,10,0.92) !important;
+  border: 1px solid #2a402a !important;
+  color: #9fcf9f !important;
+  font-size: 0.75rem !important;
+  padding: 4px 10px !important;
+  border-radius: 6px !important;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.5) !important;
+}
+
+.park-tooltip::before { display: none !important; }
+
+.leaflet-control-zoom a {
+  background: #0a150a !important;
+  color: #7ab07a !important;
+  border-color: #2a402a !important;
+}
+
+.leaflet-control-zoom a:hover {
+  background: #162916 !important;
+  color: #cde0cd !important;
+}
+
+.leaflet-control-attribution {
+  background: rgba(10,21,10,0.75) !important;
+  color: #2a4a2a !important;
+  font-size: 0.6rem !important;
+}
+
+.leaflet-control-attribution a { color: #3a6a3a !important; }


### PR DESCRIPTION
Interactive Leaflet map of SF parks/natural areas with per-park
iNaturalist species data: category breakdown (plants, birds, insects,
mammals, fungi, reptiles, amphibians, arachnids, mollusks), species
list with photos and native/introduced status, and a live biodiversity
rankings table sortable by total species, taxon group, or % native.

Data sources: SF Open Data (park polygons) + iNaturalist API v1
(research-grade observations, species_counts endpoint).

https://claude.ai/code/session_01LpMVNvRqM9umUaULcmfXHe