### PR TITLE
Remove % native column; add Natives only toggle

### DIFF
--- a/sf-parks-biodiversity/app.js
+++ b/sf-parks-biodiversity/app.js
@@ -28,6 +28,7 @@ const state = {
   detailCache: {},      // { [parkId]: { species[], cats, nativeCount, introducedCount } }
   selectedId:  null,
   sortCol:     'total',
+  nativesOnly: false,
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -204,7 +205,7 @@ function openSidebar(feature) {
 function renderSidebar(feature, detail) {
   const name  = pname(feature);
   const total = detail.species?.length ?? detail.total ?? 0;
-  const nativePct = total > 0 ? Math.round((detail.nativeCount / total) * 100) : '–';
+  const initEM = state.nativesOnly ? 'native' : 'all';
 
   const catGrid = CATEGORIES.map(c => `
     <div class="cat-pill" data-cat="${c.key}">
@@ -216,15 +217,15 @@ function renderSidebar(feature, detail) {
   document.getElementById('sidebar-content').innerHTML = `
     <div class="park-header">
       <div class="park-title">${esc(name)}</div>
-      <div class="park-meta">${total.toLocaleString()} species · ${nativePct}% native/endemic · research grade</div>
+      <div class="park-meta">${total.toLocaleString()} species · ${detail.nativeCount} native · research grade</div>
     </div>
     <div class="cat-grid">${catGrid}</div>
     <div id="em-filter">
-      <button class="em-btn active" data-em="all">All (${total})</button>
-      <button class="em-btn" data-em="native">Native (${detail.nativeCount})</button>
+      <button class="em-btn${initEM === 'all' ? ' active' : ''}" data-em="all">All (${total})</button>
+      <button class="em-btn${initEM === 'native' ? ' active' : ''}" data-em="native">Native (${detail.nativeCount})</button>
       <button class="em-btn" data-em="introduced">Introduced (${detail.introducedCount})</button>
     </div>
-    <div id="sp-list-wrap">${buildSpeciesHTML(detail.species, 'all', null)}</div>`;
+    <div id="sp-list-wrap">${buildSpeciesHTML(detail.species, initEM, null)}</div>`;
 
   let activeCat = null;
 
@@ -316,32 +317,32 @@ function renderRankings() {
   const entries = Object.entries(state.detailCache);
   if (!entries.length) return;
 
-  const col = state.sortCol;
+  const col    = state.sortCol;
+  const natv   = state.nativesOnly;
   entries.sort(([, a], [, b]) => {
-    if (col === 'native_pct') {
-      const ap = a.total > 0 ? a.nativeCount / a.total : -1;
-      const bp = b.total > 0 ? b.nativeCount / b.total : -1;
-      return bp - ap;
-    }
-    if (col === 'total') return (b.total ?? 0) - (a.total ?? 0);
-    return (b.cats?.[col] ?? 0) - (a.cats?.[col] ?? 0);
+    const av = natv ? (a.nativeCount ?? 0) : (col === 'total' ? (a.total ?? 0) : (a.cats?.[col] ?? 0));
+    const bv = natv ? (b.nativeCount ?? 0) : (col === 'total' ? (b.total ?? 0) : (b.cats?.[col] ?? 0));
+    return bv - av;
   });
 
+  // Keep the "Species" header in sync with the current mode
+  const thSp = document.getElementById('th-species');
+  if (thSp) thSp.textContent = natv ? 'Native spp' : 'Species';
+
   body.innerHTML = entries.map(([id, d], i) => {
-    const name      = state.summary[id]?.name ?? id;
-    const nativePct = d.total > 0 ? Math.round((d.nativeCount / d.total) * 100) + '%' : '–';
-    const sel       = state.selectedId === id ? 'row-selected' : '';
-    const n = v => v != null ? v.toLocaleString() : '–';
+    const name = state.summary[id]?.name ?? id;
+    const sel  = state.selectedId === id ? 'row-selected' : '';
+    const n    = v => v != null ? v.toLocaleString() : '–';
+    const displayTotal = natv ? n(d.nativeCount) : n(d.total);
     return `<tr class="${sel}" data-pid="${esc(id)}">
       <td class="td-rank">${i + 1}</td>
       <td class="td-name" title="${esc(name)}">${esc(name)}</td>
-      <td class="td-num">${n(d.total)}</td>
+      <td class="td-num">${displayTotal}</td>
       <td class="td-num">${n(d.cats?.Plantae)}</td>
       <td class="td-num">${n(d.cats?.Aves)}</td>
       <td class="td-num">${n(d.cats?.Insecta)}</td>
       <td class="td-num">${n(d.cats?.Mammalia)}</td>
       <td class="td-num">${n(d.cats?.Fungi)}</td>
-      <td class="td-num">${nativePct}</td>
     </tr>`;
   }).join('');
 
@@ -357,6 +358,27 @@ function renderRankings() {
       }
     });
   });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Natives-only toggle
+// ─────────────────────────────────────────────────────────────────────────────
+
+function toggleNativesOnly() {
+  state.nativesOnly = !state.nativesOnly;
+  document.getElementById('natives-btn').classList.toggle('active', state.nativesOnly);
+  renderRankings();
+
+  // Update open sidebar species list and EM filter buttons to match
+  const wrap = document.getElementById('sp-list-wrap');
+  if (!wrap) return;
+  currentEM = state.nativesOnly ? 'native' : 'all';
+  wrap.innerHTML = buildSpeciesHTML(
+    state.detailCache[state.selectedId]?.species ?? null,
+    currentEM, null
+  );
+  document.querySelectorAll('.em-btn').forEach(b =>
+    b.classList.toggle('active', b.dataset.em === currentEM));
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -398,6 +420,9 @@ async function init() {
 
   // Sidebar close
   document.getElementById('sidebar-close').addEventListener('click', closeSidebar);
+
+  // Natives-only toggle
+  document.getElementById('natives-btn').addEventListener('click', toggleNativesOnly);
 
   // Sort buttons
   document.querySelectorAll('.sort-btn').forEach(btn => {

--- a/sf-parks-biodiversity/index.html
+++ b/sf-parks-biodiversity/index.html
@@ -24,6 +24,7 @@
           <span id="stat-ranked">0</span>
           <label>ranked</label>
         </div>
+        <button id="natives-btn" title="Show native species only">🌿 Natives only</button>
       </div>
     </header>
 
@@ -58,7 +59,6 @@
             <button class="sort-btn" data-col="Aves">Birds</button>
             <button class="sort-btn" data-col="Insecta">Insects</button>
             <button class="sort-btn" data-col="Mammalia">Mammals</button>
-            <button class="sort-btn" data-col="native_pct">% Native</button>
           </div>
         </div>
 
@@ -68,18 +68,17 @@
               <tr>
                 <th class="th-rank">#</th>
                 <th class="th-name">Park / Natural Area</th>
-                <th class="th-num sortable" data-col="total">Species</th>
+                <th class="th-num sortable" data-col="total" id="th-species">Species</th>
                 <th class="th-num sortable" data-col="Plantae">🌿 Plants</th>
                 <th class="th-num sortable" data-col="Aves">🐦 Birds</th>
                 <th class="th-num sortable" data-col="Insecta">🦋 Insects</th>
                 <th class="th-num sortable" data-col="Mammalia">🦊 Mammals</th>
                 <th class="th-num sortable" data-col="Fungi">🍄 Fungi</th>
-                <th class="th-num sortable" data-col="native_pct">Native %</th>
               </tr>
             </thead>
             <tbody id="rankings-body">
               <tr>
-                <td colspan="9" class="empty-msg">
+                <td colspan="8" class="empty-msg">
                   Rankings loading…
                 </td>
               </tr>

--- a/sf-parks-biodiversity/style.css
+++ b/sf-parks-biodiversity/style.css
@@ -69,6 +69,27 @@ html, body {
   margin-top: 2px;
 }
 
+#natives-btn {
+  padding: 5px 13px;
+  background: #162916;
+  border: 1px solid #2a402a;
+  color: #7ab07a;
+  border-radius: 14px;
+  font-size: 0.74rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+  white-space: nowrap;
+}
+
+#natives-btn:hover { background: #1e321e; color: #cde0cd; }
+
+#natives-btn.active {
+  background: #2a5a2a;
+  border-color: #5a9b5a;
+  color: #c8f0c8;
+}
+
 /* ─── Body layout ───────────────────────────────── */
 #body-wrap {
   flex: 1;


### PR DESCRIPTION
Drops the Native % rankings column and its sort option. Adds a 🌿 Natives only toggle button in the header — when active, the rankings re-sort by native species count (column header changes to "Native spp") and the sidebar species list switches to the native filter.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpMVNvRqM9umUaULcmfXHe)_