### PR TITLE
Fix sort broken in Natives only mode

### DIFF
--- a/sf-parks-biodiversity/app.js
+++ b/sf-parks-biodiversity/app.js
@@ -319,11 +319,10 @@ function renderRankings() {
 
   const col    = state.sortCol;
   const natv   = state.nativesOnly;
-  entries.sort(([, a], [, b]) => {
-    const av = natv ? (a.nativeCount ?? 0) : (col === 'total' ? (a.total ?? 0) : (a.cats?.[col] ?? 0));
-    const bv = natv ? (b.nativeCount ?? 0) : (col === 'total' ? (b.total ?? 0) : (b.cats?.[col] ?? 0));
-    return bv - av;
-  });
+  const getVal = d =>
+    col === 'total' ? (natv ? (d.nativeCount ?? 0) : (d.total ?? 0))
+                    : (d.cats?.[col] ?? 0);
+  entries.sort(([, a], [, b]) => getVal(b) - getVal(a));
 
   // Keep the "Species" header in sync with the current mode
   const thSp = document.getElementById('th-species');


### PR DESCRIPTION
When Natives only was active, clicking any sort column had no effect because the sort always fell through to nativeCount. Fix: only substitute nativeCount when sorting by the Total column; category sorts work normally regardless of the natives toggle.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpMVNvRqM9umUaULcmfXHe)_