### PR TITLE
Fix native_cats not showing in rankings columns

### DIFF
--- a/sf-parks-biodiversity/app.js
+++ b/sf-parks-biodiversity/app.js
@@ -147,11 +147,12 @@ async function loadSummary() {
   // Populate rankings immediately from summary
   for (const [id, data] of Object.entries(summary)) {
     state.detailCache[id] = {
-      species: null,  // not yet loaded
-      cats:    data.cats || {},
-      nativeCount:    data.nativeCount || 0,
-      introducedCount:data.introducedCount || 0,
-      total:   data.total || 0,
+      species:        null,  // not yet loaded
+      cats:           data.cats        || {},
+      native_cats:    data.native_cats || {},
+      nativeCount:    data.nativeCount    || 0,
+      introducedCount:data.introducedCount|| 0,
+      total:          data.total          || 0,
     };
   }
   renderRankings();


### PR DESCRIPTION
loadSummary() was discarding the native_cats field when populating detailCache, so the Plants/Birds/etc columns always read undefined when Natives only was active. One missing line fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpMVNvRqM9umUaULcmfXHe)_