### PR TITLE
Add nursery availability feature with nightly scraper

### DIFF
--- a/.github/workflows/update-nurseries.yml
+++ b/.github/workflows/update-nurseries.yml
@@ -1,0 +1,31 @@
+name: Update nursery inventory
+
+on:
+  schedule:
+    - cron: '0 8 * * *'   # 00:00 Pacific Time (UTC-8)
+  workflow_dispatch:
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Scrape nurseries
+        run: python sf-parks-biodiversity/scrape_nurseries.py
+
+      - name: Commit if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add sf-parks-biodiversity/data/nursery_inventory.json
+          git diff --staged --quiet || (
+            git commit -m "chore: update nursery inventory $(date -u +%Y-%m-%d)" &&
+            git push
+          )

--- a/sf-parks-biodiversity/app.js
+++ b/sf-parks-biodiversity/app.js
@@ -23,13 +23,15 @@ const CATEGORIES = [
 // ─────────────────────────────────────────────────────────────────────────────
 
 const state = {
-  parks:       [],
-  summary:     {},
-  detailCache: {},
-  selectedId:  null,
-  sortCol:     'total',
-  nativeMode:  'all',   // 'all' | 'ca' | 'sf'
-  sfNatives:   new Set(),
+  parks:        [],
+  summary:      {},
+  detailCache:  {},
+  selectedId:   null,
+  sortCol:      'total',
+  nativeMode:   'all',   // 'all' | 'ca' | 'sf'
+  sfNatives:    new Set(),
+  nurseries:    {},
+  nurseryIndex: new Map(),  // 'Genus species' → ['nursery_id', …]
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -137,6 +139,19 @@ async function loadSFNatives() {
   state.sfNatives = new Set(
     text.split('\n').map(l => l.trim()).filter(Boolean)
   );
+}
+
+async function loadNurseries() {
+  try {
+    const [nurseries, inventory] = await Promise.all([
+      loadJSON(`${DATA_ROOT}/nurseries.json`),
+      loadJSON(`${DATA_ROOT}/nursery_inventory.json`),
+    ]);
+    state.nurseries = nurseries;
+    state.nurseryIndex = new Map(Object.entries(inventory.bySpecies ?? {}));
+  } catch (e) {
+    console.warn('Nursery data not available:', e.message);
+  }
 }
 
 async function loadParks() {
@@ -335,13 +350,18 @@ function speciesItemHTML(s) {
 
   const catBadge = cat ? `<span class="badge badge-cat">${cat.icon} ${cat.label}</span>` : '';
 
+  const speciesKey = sci.split(' ').slice(0, 2).join(' ');
+  const nurseryBadge = state.nurseryIndex.has(speciesKey)
+    ? `<button class="badge badge-nursery" data-species="${esc(speciesKey)}">🪴 buy local</button>`
+    : '';
+
   return `
     <div class="sp-item">
       ${photoEl}
       <div class="sp-info">
         <div class="sp-common">${esc(common)}</div>
         <div class="sp-sci">${esc(sci)}</div>
-        <div class="sp-badges">${catBadge}${emBadge}</div>
+        <div class="sp-badges">${catBadge}${emBadge}${nurseryBadge}</div>
         <div class="sp-obs">${s.count.toLocaleString()} obs</div>
       </div>
     </div>`;
@@ -447,6 +467,62 @@ function esc(s) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Nursery modal
+// ─────────────────────────────────────────────────────────────────────────────
+
+let _nurseryMap = null;
+
+function openNurseryModal(speciesKey) {
+  const nurseryIds = state.nurseryIndex.get(speciesKey) ?? [];
+  document.getElementById('nursery-modal-title').textContent =
+    `Buy ${speciesKey} at a local nursery`;
+
+  document.getElementById('nursery-modal-list').innerHTML = nurseryIds.map(id => {
+    const n = state.nurseries[id];
+    if (!n) return '';
+    return `<div class="nursery-card">
+      <div class="nursery-card-name">${esc(n.name)}</div>
+      <div class="nursery-card-address">${esc(n.address)}</div>
+      ${n.phone ? `<div class="nursery-card-phone">${esc(n.phone)}</div>` : ''}
+      <a href="${esc(n.website)}" target="_blank" rel="noopener" class="nursery-card-link">Visit website →</a>
+      <a href="https://www.openstreetmap.org/directions?to=${n.lat},${n.lng}" target="_blank" rel="noopener" class="nursery-card-link">Get directions →</a>
+    </div>`;
+  }).join('');
+
+  document.getElementById('nursery-modal').classList.remove('hidden');
+
+  setTimeout(() => {
+    if (!_nurseryMap) {
+      _nurseryMap = L.map('nursery-modal-map').setView([37.85, -122.3], 11);
+      L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/">CARTO</a>',
+        subdomains: 'abcd', maxZoom: 20,
+      }).addTo(_nurseryMap);
+    }
+    _nurseryMap.invalidateSize();
+
+    _nurseryMap.eachLayer(l => { if (l instanceof L.Marker) _nurseryMap.removeLayer(l); });
+
+    const markers = nurseryIds.map(id => state.nurseries[id]).filter(n => n?.lat && n?.lng).map(n => {
+      const m = L.marker([n.lat, n.lng]).addTo(_nurseryMap);
+      m.bindPopup(`<strong>${n.name}</strong><br>${n.address}`).openPopup();
+      return m;
+    });
+
+    if (markers.length === 1) {
+      const n = state.nurseries[nurseryIds[0]];
+      _nurseryMap.setView([n.lat, n.lng], 14);
+    } else if (markers.length > 1) {
+      _nurseryMap.fitBounds(L.featureGroup(markers).getBounds().pad(0.3));
+    }
+  }, 50);
+}
+
+function closeNurseryModal() {
+  document.getElementById('nursery-modal').classList.add('hidden');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Init
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -460,10 +536,20 @@ async function init() {
   }
 
   loadSummary().catch(e => console.warn('Summary not yet available:', e.message));
+  loadNurseries();
 
   document.getElementById('sidebar-close').addEventListener('click', closeSidebar);
   document.getElementById('ca-natives-btn').addEventListener('click', () => toggleNativeMode('ca'));
   document.getElementById('sf-natives-btn').addEventListener('click', () => toggleNativeMode('sf'));
+
+  document.getElementById('nursery-modal-close').addEventListener('click', closeNurseryModal);
+  document.getElementById('nursery-modal-backdrop').addEventListener('click', closeNurseryModal);
+  document.addEventListener('keydown', e => { if (e.key === 'Escape') closeNurseryModal(); });
+
+  document.addEventListener('click', e => {
+    const badge = e.target.closest('.badge-nursery');
+    if (badge) { e.stopPropagation(); openNurseryModal(badge.dataset.species); }
+  });
 
   document.querySelectorAll('.sort-btn').forEach(btn => {
     btn.addEventListener('click', () => {

--- a/sf-parks-biodiversity/data/nurseries.json
+++ b/sf-parks-biodiversity/data/nurseries.json
@@ -1,0 +1,11 @@
+{
+  "oaktown": {
+    "name": "Oaktown Native Plant Nursery",
+    "address": "702 Channing Way, Berkeley, CA",
+    "phone": "510-387-9744",
+    "website": "https://oaktownnursery.com",
+    "inventoryUrl": "https://oakrails.oaktownnursery.com/item/invList",
+    "lat": 37.8645,
+    "lng": -122.2998
+  }
+}

--- a/sf-parks-biodiversity/data/nursery_inventory.json
+++ b/sf-parks-biodiversity/data/nursery_inventory.json
@@ -1,0 +1,272 @@
+{
+  "lastUpdated": "2026-04-26",
+  "bySpecies": {
+    "Achillea millefolium": [
+      "oaktown"
+    ],
+    "Aesculus californica": [
+      "oaktown"
+    ],
+    "Anisocarpus madioides": [
+      "oaktown"
+    ],
+    "Aquilegia formosa": [
+      "oaktown"
+    ],
+    "Arbutus menziesii": [
+      "oaktown"
+    ],
+    "Armeria maritima": [
+      "oaktown"
+    ],
+    "Artemisia californica": [
+      "oaktown"
+    ],
+    "Baccharis pilularis": [
+      "oaktown"
+    ],
+    "Calamagrostis nutkaensis": [
+      "oaktown"
+    ],
+    "Camissoniopsis cheiranthifolia": [
+      "oaktown"
+    ],
+    "Carex barbarae": [
+      "oaktown"
+    ],
+    "Carex densa": [
+      "oaktown"
+    ],
+    "Carex pansa": [
+      "oaktown"
+    ],
+    "Carex tumulicola": [
+      "oaktown"
+    ],
+    "Ceanothus thyrsiflorus": [
+      "oaktown"
+    ],
+    "Cirsium occidentale": [
+      "oaktown"
+    ],
+    "Clarkia rubicunda": [
+      "oaktown"
+    ],
+    "Collinsia heterophylla": [
+      "oaktown"
+    ],
+    "Corylus cornuta": [
+      "oaktown"
+    ],
+    "Danthonia californica": [
+      "oaktown"
+    ],
+    "Drymocallis glandulosa": [
+      "oaktown"
+    ],
+    "Dudleya farinosa": [
+      "oaktown"
+    ],
+    "Elymus glaucus": [
+      "oaktown"
+    ],
+    "Elymus triticoides": [
+      "oaktown"
+    ],
+    "Erigeron glaucus": [
+      "oaktown"
+    ],
+    "Eriogonum latifolium": [
+      "oaktown"
+    ],
+    "Eriophyllum staechadifolium": [
+      "oaktown"
+    ],
+    "Erythranthe cardinalis": [
+      "oaktown"
+    ],
+    "Erythranthe guttata": [
+      "oaktown"
+    ],
+    "Eschscholzia californica": [
+      "oaktown"
+    ],
+    "Euthamia occidentalis": [
+      "oaktown"
+    ],
+    "Festuca idahoensis": [
+      "oaktown"
+    ],
+    "Fragaria chiloensis": [
+      "oaktown"
+    ],
+    "Fragaria vesca": [
+      "oaktown"
+    ],
+    "Frangula californica": [
+      "oaktown"
+    ],
+    "Garrya elliptica": [
+      "oaktown"
+    ],
+    "Gilia capitata": [
+      "oaktown"
+    ],
+    "Grindelia hirsutula": [
+      "oaktown"
+    ],
+    "Grindelia stricta": [
+      "oaktown"
+    ],
+    "Heliotropium curassavicum": [
+      "oaktown"
+    ],
+    "Heteromeles arbutifolia": [
+      "oaktown"
+    ],
+    "Heuchera micrantha": [
+      "oaktown"
+    ],
+    "Holodiscus discolor": [
+      "oaktown"
+    ],
+    "Horkelia californica": [
+      "oaktown"
+    ],
+    "Iris douglasiana": [
+      "oaktown"
+    ],
+    "Juncus balticus": [
+      "oaktown"
+    ],
+    "Juncus effusus": [
+      "oaktown"
+    ],
+    "Juncus mexicanus": [
+      "oaktown"
+    ],
+    "Juncus patens": [
+      "oaktown"
+    ],
+    "Juncus xiphioides": [
+      "oaktown"
+    ],
+    "Koeleria macrantha": [
+      "oaktown"
+    ],
+    "Lasthenia californica": [
+      "oaktown"
+    ],
+    "Lepechinia calycina": [
+      "oaktown"
+    ],
+    "Lupinus albifrons": [
+      "oaktown"
+    ],
+    "Lupinus polyphyllus": [
+      "oaktown"
+    ],
+    "Lupinus succulentus": [
+      "oaktown"
+    ],
+    "Madia elegans": [
+      "oaktown"
+    ],
+    "Melica torreyana": [
+      "oaktown"
+    ],
+    "Monardella villosa": [
+      "oaktown"
+    ],
+    "Perideridia kelloggii": [
+      "oaktown"
+    ],
+    "Phacelia californica": [
+      "oaktown"
+    ],
+    "Plantago erecta": [
+      "oaktown"
+    ],
+    "Polypodium californicum": [
+      "oaktown"
+    ],
+    "Polystichum munitum": [
+      "oaktown"
+    ],
+    "Quercus agrifolia": [
+      "oaktown"
+    ],
+    "Quercus parvula": [
+      "oaktown"
+    ],
+    "Rhododendron occidentale": [
+      "oaktown"
+    ],
+    "Ribes divaricatum": [
+      "oaktown"
+    ],
+    "Ribes malvaceum": [
+      "oaktown"
+    ],
+    "Ribes menziesii": [
+      "oaktown"
+    ],
+    "Ribes sanguineum": [
+      "oaktown"
+    ],
+    "Rosa gymnocarpa": [
+      "oaktown"
+    ],
+    "Rubus parviflorus": [
+      "oaktown"
+    ],
+    "Rubus ursinus": [
+      "oaktown"
+    ],
+    "Sambucus nigra": [
+      "oaktown"
+    ],
+    "Sanicula crassicaulis": [
+      "oaktown"
+    ],
+    "Scrophularia californica": [
+      "oaktown"
+    ],
+    "Sedum spathulifolium": [
+      "oaktown"
+    ],
+    "Sisyrinchium bellum": [
+      "oaktown"
+    ],
+    "Solidago velutina": [
+      "oaktown"
+    ],
+    "Stachys chamissonis": [
+      "oaktown"
+    ],
+    "Symphoricarpos albus": [
+      "oaktown"
+    ],
+    "Symphoricarpos mollis": [
+      "oaktown"
+    ],
+    "Tellima grandiflora": [
+      "oaktown"
+    ],
+    "Thalictrum fendleri": [
+      "oaktown"
+    ],
+    "Toxicoscordion fremontii": [
+      "oaktown"
+    ],
+    "Triteleia laxa": [
+      "oaktown"
+    ],
+    "Urtica dioica": [
+      "oaktown"
+    ],
+    "Woodwardia fimbriata": [
+      "oaktown"
+    ]
+  }
+}

--- a/sf-parks-biodiversity/index.html
+++ b/sf-parks-biodiversity/index.html
@@ -96,6 +96,19 @@
     </div><!-- /body-wrap -->
   </div><!-- /app -->
 
+  <!-- Nursery modal -->
+  <div id="nursery-modal" class="hidden">
+    <div id="nursery-modal-backdrop"></div>
+    <div id="nursery-modal-box">
+      <button id="nursery-modal-close" title="Close">✕</button>
+      <h3 id="nursery-modal-title"></h3>
+      <div id="nursery-modal-body">
+        <div id="nursery-modal-list"></div>
+        <div id="nursery-modal-map"></div>
+      </div>
+    </div>
+  </div>
+
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script src="app.js"></script>
 </body>

--- a/sf-parks-biodiversity/scrape_nurseries.py
+++ b/sf-parks-biodiversity/scrape_nurseries.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+Scrapes nursery websites and updates data/nursery_inventory.json.
+Run from any directory; paths are resolved relative to this script.
+"""
+
+import html as html_lib
+import json
+import re
+import urllib.request
+from datetime import date
+from pathlib import Path
+
+DATA_DIR = Path(__file__).parent / "data"
+
+
+def parse_species_name(raw: str) -> str:
+    name = html_lib.unescape(raw).strip()
+    name = re.sub(r"\s*'[^']*'.*$", "", name)   # strip cultivar names
+    name = re.sub(r"\s+var\.\s+\S+.*$", "", name)  # strip var. designations
+    return name.strip()
+
+
+def genus_species(name: str) -> str:
+    parts = name.split()
+    return " ".join(parts[:2]) if len(parts) >= 2 else name
+
+
+def scrape_oaktown(url: str) -> list:
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "Mozilla/5.0 nature-in-sf/nursery-scraper"}
+    )
+    with urllib.request.urlopen(req, timeout=30) as r:
+        content = r.read().decode("utf-8")
+
+    raw_names = re.findall(r'<td class="species"><a[^>]*>([^<]+)</a>', content)
+    seen = set()
+    result = []
+    for raw in raw_names:
+        name = parse_species_name(raw)
+        if not name or len(name.split()) < 2:
+            continue
+        gs = genus_species(name)
+        if gs not in seen:
+            seen.add(gs)
+            result.append(gs)
+    return result
+
+
+SCRAPERS = {
+    "oaktown": scrape_oaktown,
+}
+
+
+def main():
+    with open(DATA_DIR / "nurseries.json") as f:
+        nurseries = json.load(f)
+
+    with open(DATA_DIR / "sf_natives.csv") as f:
+        sf_natives = {line.strip() for line in f if line.strip()}
+
+    by_species = {}
+
+    for nursery_id, info in nurseries.items():
+        scraper = SCRAPERS.get(nursery_id)
+        if not scraper or "inventoryUrl" not in info:
+            continue
+        print(f"Scraping {info['name']} ...", flush=True)
+        try:
+            species = scraper(info["inventoryUrl"])
+            matched = 0
+            for gs in species:
+                if gs in sf_natives:
+                    by_species.setdefault(gs, []).append(nursery_id)
+                    matched += 1
+            print(f"  {len(species)} unique species, {matched} SF native matches")
+        except Exception as exc:
+            print(f"  ERROR: {exc}")
+
+    inventory = {
+        "lastUpdated": date.today().isoformat(),
+        "bySpecies": dict(sorted(by_species.items())),
+    }
+
+    out = DATA_DIR / "nursery_inventory.json"
+    with open(out, "w") as f:
+        json.dump(inventory, f, indent=2)
+    print(f"Wrote {len(by_species)} species to {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/sf-parks-biodiversity/style.css
+++ b/sf-parks-biodiversity/style.css
@@ -370,6 +370,12 @@ html, body {
 .badge-introduced  { background: #fef3e6; color: #a05a1a; border: 1px solid #f0ceaa; }
 .badge-naturalizing{ background: #fdf6e6; color: #8a6010; border: 1px solid #eadcaa; }
 .badge-cat         { background: var(--green-pale); color: var(--green); border: 1px solid #c0d8c8; }
+.badge-nursery {
+  background: #fff8e6; color: #7a5200; border: 1px solid #f0d890;
+  cursor: pointer; font-family: inherit;
+  transition: background 0.15s;
+}
+.badge-nursery:hover { background: #ffefc0; }
 
 .sp-obs {
   font-size: 0.62rem;
@@ -598,3 +604,75 @@ html, body {
 }
 
 .leaflet-control-attribution a { color: var(--green) !important; }
+
+/* ─── Nursery modal ─────────────────────────────── */
+#nursery-modal {
+  position: fixed; inset: 0; z-index: 10000;
+  display: flex; align-items: center; justify-content: center;
+}
+#nursery-modal.hidden { display: none; }
+
+#nursery-modal-backdrop {
+  position: absolute; inset: 0;
+  background: rgba(44, 56, 40, 0.45);
+}
+
+#nursery-modal-box {
+  position: relative; z-index: 1;
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  box-shadow: var(--shadow-lg);
+  width: min(760px, 94vw);
+  max-height: 86vh;
+  display: flex; flex-direction: column;
+  overflow: hidden;
+}
+
+#nursery-modal-close {
+  position: absolute; top: 12px; right: 14px;
+  background: none; border: none; cursor: pointer;
+  font-size: 1rem; color: var(--text-muted); line-height: 1;
+  padding: 4px 6px; border-radius: 6px;
+}
+#nursery-modal-close:hover { background: var(--bg-hover); color: var(--text); }
+
+#nursery-modal-title {
+  padding: 18px 20px 12px;
+  font-size: 0.95rem; font-weight: 600; color: var(--text);
+  border-bottom: 1px solid var(--border-soft);
+  font-style: italic;
+}
+
+#nursery-modal-body {
+  display: flex; flex: 1; overflow: hidden;
+}
+
+#nursery-modal-list {
+  width: 260px; flex-shrink: 0;
+  padding: 16px;
+  overflow-y: auto;
+  border-right: 1px solid var(--border-soft);
+}
+
+#nursery-modal-map {
+  flex: 1; min-height: 320px;
+}
+
+.nursery-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-soft);
+  border-radius: 10px;
+  padding: 12px 14px;
+  margin-bottom: 10px;
+  display: flex; flex-direction: column; gap: 4px;
+}
+.nursery-card-name  { font-weight: 600; font-size: 0.82rem; color: var(--text); }
+.nursery-card-address, .nursery-card-phone {
+  font-size: 0.75rem; color: var(--text-mid);
+}
+.nursery-card-link  {
+  font-size: 0.75rem; color: var(--green);
+  text-decoration: none; margin-top: 2px;
+}
+.nursery-card-link:hover { text-decoration: underline; }


### PR DESCRIPTION
Adds a "🪴 buy local" badge to SF native plant species available at nearby nurseries, with a modal showing nursery details and a map.

## Changes

### UI
- **🪴 buy local** badge on SF native species available at a local nursery (amber badge alongside existing native/category badges)
- Clicking the badge opens a modal with nursery name, address, phone, website link, directions link, and a Leaflet map with marker
- Modal closes on ✕, backdrop click, or Escape

### Data
- `data/nurseries.json` — static nursery metadata (Oaktown Native Plant Nursery, 702 Channing Way, Berkeley)
- `data/nursery_inventory.json` — 89 SF native species currently in stock at Oaktown (scraped from 185-species inventory)

### Scraper
- `scrape_nurseries.py` — fetches Oaktown's inventory page, parses `td.species a`, strips cultivar names and `var.` designations, keeps subspecies, cross-references against `sf_natives.csv`

### Automation
- `.github/workflows/update-nurseries.yml` — nightly cron at midnight Pacific; runs scraper, commits `nursery_inventory.json` only when inventory changes

https://claude.ai/code/session_01LpMVNvRqM9umUaULcmfXHe

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpMVNvRqM9umUaULcmfXHe)_