### PR TITLE
Add Sutro Stewards Native Plant Nursery

### DIFF
--- a/sf-parks-biodiversity/data/nurseries.json
+++ b/sf-parks-biodiversity/data/nurseries.json
@@ -7,5 +7,13 @@
     "inventoryUrl": "https://oakrails.oaktownnursery.com/item/invList",
     "lat": 37.8645,
     "lng": -122.2998
+  },
+  "sutro": {
+    "name": "Sutro Stewards Native Plant Nursery",
+    "address": "476 Johnstone Drive, San Francisco, CA 94131",
+    "website": "https://www.sutrostewards.org/shop",
+    "inventoryUrl": "https://www.sutrostewards.org/shop",
+    "lat": 37.757342,
+    "lng": -122.4567715
   }
 }

--- a/sf-parks-biodiversity/data/nursery_inventory.json
+++ b/sf-parks-biodiversity/data/nursery_inventory.json
@@ -2,7 +2,8 @@
   "lastUpdated": "2026-04-26",
   "bySpecies": {
     "Achillea millefolium": [
-      "oaktown"
+      "oaktown",
+      "sutro"
     ],
     "Aesculus californica": [
       "oaktown"
@@ -74,19 +75,25 @@
       "oaktown"
     ],
     "Erigeron glaucus": [
-      "oaktown"
+      "oaktown",
+      "sutro"
     ],
     "Eriogonum latifolium": [
-      "oaktown"
+      "oaktown",
+      "sutro"
     ],
     "Eriophyllum staechadifolium": [
       "oaktown"
+    ],
+    "Erysimum franciscanum": [
+      "sutro"
     ],
     "Erythranthe cardinalis": [
       "oaktown"
     ],
     "Erythranthe guttata": [
-      "oaktown"
+      "oaktown",
+      "sutro"
     ],
     "Eschscholzia californica": [
       "oaktown"
@@ -101,7 +108,8 @@
       "oaktown"
     ],
     "Fragaria vesca": [
-      "oaktown"
+      "oaktown",
+      "sutro"
     ],
     "Frangula californica": [
       "oaktown"
@@ -160,6 +168,9 @@
     "Lepechinia calycina": [
       "oaktown"
     ],
+    "Lonicera involucrata": [
+      "sutro"
+    ],
     "Lupinus albifrons": [
       "oaktown"
     ],
@@ -212,7 +223,8 @@
       "oaktown"
     ],
     "Ribes sanguineum": [
-      "oaktown"
+      "oaktown",
+      "sutro"
     ],
     "Rosa gymnocarpa": [
       "oaktown"
@@ -237,6 +249,9 @@
     ],
     "Sisyrinchium bellum": [
       "oaktown"
+    ],
+    "Sisyrinchium californicum": [
+      "sutro"
     ],
     "Solidago velutina": [
       "oaktown"

--- a/sf-parks-biodiversity/scrape_nurseries.py
+++ b/sf-parks-biodiversity/scrape_nurseries.py
@@ -47,8 +47,35 @@ def scrape_oaktown(url: str) -> list:
     return result
 
 
+def scrape_sutro(url: str) -> list:
+    """Return list of genus+species strings from Sutro Stewards shop (Wix).
+    Product names embed the scientific name in parentheses, e.g.
+    'Yarrow (Achillea millefolium) Short Tree Pot potted plant'."""
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "Mozilla/5.0 nature-in-sf/nursery-scraper"}
+    )
+    with urllib.request.urlopen(req, timeout=30) as r:
+        content = r.read().decode("utf-8", errors="replace")
+
+    # Scientific names appear in parentheses inside product name strings in the
+    # embedded Wix JSON: "name":"Common Name (Genus species) pot description"
+    raw_names = re.findall(
+        r'"name":"[^"]*\(([A-Z][a-z]+(?: [a-z]+)+(?:\s+(?:ssp|subsp|var)\.[^)]*)?)\)',
+        content,
+    )
+    seen = set()
+    result = []
+    for name in raw_names:
+        gs = genus_species(name.strip())
+        if gs not in seen:
+            seen.add(gs)
+            result.append(gs)
+    return result
+
+
 SCRAPERS = {
     "oaktown": scrape_oaktown,
+    "sutro":   scrape_sutro,
 }
 
 


### PR DESCRIPTION
Adds the Sutro Stewards nursery at Mount Sutro Open Space as a second source for the "🪴 buy local" badge.

## Changes
- `nurseries.json` — adds `sutro` entry (476 Johnstone Drive, SF 94131; lat/lng from their Wix site metadata)
- `scrape_nurseries.py` — adds `scrape_sutro()`: fetches the Wix shop page and extracts scientific names from the parenthetical format in product titles, e.g. `"Yarrow (Achillea millefolium) Short Tree Pot potted plant"`
- `nursery_inventory.json` — regenerated; 9 Sutro species all SF native, 3 exclusive to Sutro (Sisyrinchium californicum, Lonicera involucrata, Erysimum franciscanum); total 92 species across 2 nurseries

The nightly GitHub Action already handles both nurseries with no changes needed to the workflow.

https://claude.ai/code/session_01LpMVNvRqM9umUaULcmfXHe

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpMVNvRqM9umUaULcmfXHe)_