### PR TITLE
Add Heron's Head Nursery; improve scraper resilience

### DIFF
--- a/sf-parks-biodiversity/data/nurseries.json
+++ b/sf-parks-biodiversity/data/nurseries.json
@@ -15,5 +15,14 @@
     "inventoryUrl": "https://www.sutrostewards.org/shop",
     "lat": 37.757342,
     "lng": -122.4567715
+  },
+  "heronshead": {
+    "name": "Heron's Head Nursery",
+    "address": "98 Jennings St., San Francisco, CA 94124",
+    "phone": "(415) 510-2500",
+    "website": "https://heronsheadnursery.com",
+    "inventoryUrl": "https://heronsheadnursery.com/collections/california-natives",
+    "lat": 37.7428,
+    "lng": -122.3817
   }
 }

--- a/sf-parks-biodiversity/data/nursery_inventory.json
+++ b/sf-parks-biodiversity/data/nursery_inventory.json
@@ -1,36 +1,74 @@
 {
   "lastUpdated": "2026-04-26",
   "bySpecies": {
+    "Abronia latifolia": [
+      "heronshead"
+    ],
+    "Acer negundo": [
+      "heronshead"
+    ],
     "Achillea millefolium": [
       "oaktown",
-      "sutro"
+      "sutro",
+      "heronshead"
+    ],
+    "Acmispon heermannii": [
+      "heronshead"
     ],
     "Aesculus californica": [
-      "oaktown"
+      "oaktown",
+      "heronshead"
+    ],
+    "Ambrosia chamissonis": [
+      "heronshead"
     ],
     "Anisocarpus madioides": [
       "oaktown"
     ],
     "Aquilegia formosa": [
-      "oaktown"
+      "oaktown",
+      "heronshead"
     ],
     "Arbutus menziesii": [
       "oaktown"
     ],
+    "Arctostaphylos manzanita": [
+      "heronshead"
+    ],
+    "Aristolochia californica": [
+      "heronshead"
+    ],
     "Armeria maritima": [
-      "oaktown"
+      "oaktown",
+      "heronshead"
     ],
     "Artemisia californica": [
-      "oaktown"
+      "oaktown",
+      "heronshead"
+    ],
+    "Artemisia douglasiana": [
+      "heronshead"
+    ],
+    "Artemisia pycnocephala": [
+      "heronshead"
+    ],
+    "Asarum caudatum": [
+      "heronshead"
     ],
     "Baccharis pilularis": [
-      "oaktown"
+      "oaktown",
+      "heronshead"
     ],
     "Calamagrostis nutkaensis": [
-      "oaktown"
+      "oaktown",
+      "heronshead"
+    ],
+    "Calystegia occidentalis": [
+      "heronshead"
     ],
     "Camissoniopsis cheiranthifolia": [
-      "oaktown"
+      "oaktown",
+      "heronshead"
     ],
     "Carex barbarae": [
       "oaktown"
@@ -41,20 +79,29 @@
     "Carex pansa": [
       "oaktown"
     ],
+    "Carex praegracilis": [
+      "heronshead"
+    ],
     "Carex tumulicola": [
-      "oaktown"
+      "oaktown",
+      "heronshead"
     ],
     "Ceanothus thyrsiflorus": [
-      "oaktown"
+      "oaktown",
+      "heronshead"
     ],
     "Cirsium occidentale": [
       "oaktown"
+    ],
+    "Clarkia amoena": [
+      "heronshead"
     ],
     "Clarkia rubicunda": [
       "oaktown"
     ],
     "Collinsia heterophylla": [
-      "oaktown"
+      "oaktown",
+      "heronshead"
     ],
     "Corylus cornuta": [
       "oaktown"
@@ -62,11 +109,15 @@
     "Danthonia californica": [
       "oaktown"
     ],
+    "Deschampsia cespitosa": [
+      "heronshead"
+    ],
     "Drymocallis glandulosa": [
       "oaktown"
     ],
     "Dudleya farinosa": [
-      "oaktown"
+      "oaktown",
+      "heronshead"
     ],
     "Elymus glaucus": [
       "oaktown"
@@ -74,16 +125,25 @@
     "Elymus triticoides": [
       "oaktown"
     ],
+    "Ericameria ericoides": [
+      "heronshead"
+    ],
     "Erigeron glaucus": [
       "oaktown",
-      "sutro"
+      "sutro",
+      "heronshead"
     ],
     "Eriogonum latifolium": [
       "oaktown",
-      "sutro"
+      "sutro",
+      "heronshead"
+    ],
+    "Eriophyllum lanatum": [
+      "heronshead"
     ],
     "Eriophyllum staechadifolium": [
-      "oaktown"
+      "oaktown",
+      "heronshead"
     ],
     "Erysimum franciscanum": [
       "sutro"
@@ -96,16 +156,22 @@
       "sutro"
     ],
     "Eschscholzia californica": [
-      "oaktown"
+      "oaktown",
+      "heronshead"
     ],
     "Euthamia occidentalis": [
       "oaktown"
     ],
+    "Festuca californica": [
+      "heronshead"
+    ],
     "Festuca idahoensis": [
-      "oaktown"
+      "oaktown",
+      "heronshead"
     ],
     "Fragaria chiloensis": [
-      "oaktown"
+      "oaktown",
+      "heronshead"
     ],
     "Fragaria vesca": [
       "oaktown",
@@ -115,7 +181,8 @@
       "oaktown"
     ],
     "Garrya elliptica": [
-      "oaktown"
+      "oaktown",
+      "heronshead"
     ],
     "Gilia capitata": [
       "oaktown"
@@ -126,35 +193,44 @@
     "Grindelia stricta": [
       "oaktown"
     ],
+    "Helenium puberulum": [
+      "heronshead"
+    ],
     "Heliotropium curassavicum": [
       "oaktown"
     ],
     "Heteromeles arbutifolia": [
-      "oaktown"
+      "oaktown",
+      "heronshead"
     ],
     "Heuchera micrantha": [
-      "oaktown"
+      "oaktown",
+      "heronshead"
     ],
     "Holodiscus discolor": [
       "oaktown"
     ],
     "Horkelia californica": [
-      "oaktown"
+      "oaktown",
+      "heronshead"
     ],
     "Iris douglasiana": [
-      "oaktown"
+      "oaktown",
+      "heronshead"
     ],
     "Juncus balticus": [
       "oaktown"
     ],
     "Juncus effusus": [
-      "oaktown"
+      "oaktown",
+      "heronshead"
     ],
     "Juncus mexicanus": [
       "oaktown"
     ],
     "Juncus patens": [
-      "oaktown"
+      "oaktown",
+      "heronshead"
     ],
     "Juncus xiphioides": [
       "oaktown"
@@ -178,7 +254,8 @@
       "oaktown"
     ],
     "Lupinus succulentus": [
-      "oaktown"
+      "oaktown",
+      "heronshead"
     ],
     "Madia elegans": [
       "oaktown"
@@ -187,13 +264,15 @@
       "oaktown"
     ],
     "Monardella villosa": [
-      "oaktown"
+      "oaktown",
+      "heronshead"
     ],
     "Perideridia kelloggii": [
       "oaktown"
     ],
     "Phacelia californica": [
-      "oaktown"
+      "oaktown",
+      "heronshead"
     ],
     "Plantago erecta": [
       "oaktown"
@@ -202,29 +281,49 @@
       "oaktown"
     ],
     "Polystichum munitum": [
-      "oaktown"
+      "oaktown",
+      "heronshead"
+    ],
+    "Prunella vulgaris": [
+      "heronshead"
+    ],
+    "Prunus ilicifolia": [
+      "heronshead"
+    ],
+    "Pseudognaphalium stramineum": [
+      "heronshead"
     ],
     "Quercus agrifolia": [
-      "oaktown"
+      "oaktown",
+      "heronshead"
     ],
     "Quercus parvula": [
       "oaktown"
     ],
+    "Ranunculus californicus": [
+      "heronshead"
+    ],
+    "Rhamnus crocea": [
+      "heronshead"
+    ],
     "Rhododendron occidentale": [
-      "oaktown"
+      "oaktown",
+      "heronshead"
     ],
     "Ribes divaricatum": [
       "oaktown"
     ],
     "Ribes malvaceum": [
-      "oaktown"
+      "oaktown",
+      "heronshead"
     ],
     "Ribes menziesii": [
       "oaktown"
     ],
     "Ribes sanguineum": [
       "oaktown",
-      "sutro"
+      "sutro",
+      "heronshead"
     ],
     "Rosa gymnocarpa": [
       "oaktown"
@@ -235,6 +334,9 @@
     "Rubus ursinus": [
       "oaktown"
     ],
+    "Salvia spathacea": [
+      "heronshead"
+    ],
     "Sambucus nigra": [
       "oaktown"
     ],
@@ -242,19 +344,24 @@
       "oaktown"
     ],
     "Scrophularia californica": [
-      "oaktown"
+      "oaktown",
+      "heronshead"
     ],
     "Sedum spathulifolium": [
-      "oaktown"
+      "oaktown",
+      "heronshead"
     ],
     "Sisyrinchium bellum": [
-      "oaktown"
+      "oaktown",
+      "heronshead"
     ],
     "Sisyrinchium californicum": [
-      "sutro"
+      "sutro",
+      "heronshead"
     ],
     "Solidago velutina": [
-      "oaktown"
+      "oaktown",
+      "heronshead"
     ],
     "Stachys chamissonis": [
       "oaktown"
@@ -263,7 +370,8 @@
       "oaktown"
     ],
     "Symphoricarpos mollis": [
-      "oaktown"
+      "oaktown",
+      "heronshead"
     ],
     "Tellima grandiflora": [
       "oaktown"
@@ -280,8 +388,15 @@
     "Urtica dioica": [
       "oaktown"
     ],
+    "Vaccinium ovatum": [
+      "heronshead"
+    ],
+    "Viola adunca": [
+      "heronshead"
+    ],
     "Woodwardia fimbriata": [
-      "oaktown"
+      "oaktown",
+      "heronshead"
     ]
   }
 }

--- a/sf-parks-biodiversity/scrape_nurseries.py
+++ b/sf-parks-biodiversity/scrape_nurseries.py
@@ -7,6 +7,7 @@ Run from any directory; paths are resolved relative to this script.
 import html as html_lib
 import json
 import re
+import time
 import urllib.request
 from datetime import date
 from pathlib import Path
@@ -73,9 +74,45 @@ def scrape_sutro(url: str) -> list:
     return result
 
 
+def scrape_heronshead(url: str) -> list:
+    """Return in-stock genus+species from Heron's Head Nursery (Shopify).
+    Uses the Shopify /products.json API; filters to variants with available=true."""
+    collection_base = re.sub(r'\?.*$', '', url.rstrip('/'))
+    seen = set()
+    result = []
+    page = 1
+    while True:
+        api_url = f"{collection_base}/products.json?limit=250&page={page}"
+        req = urllib.request.Request(
+            api_url, headers={"User-Agent": "Mozilla/5.0 nature-in-sf/nursery-scraper"}
+        )
+        with urllib.request.urlopen(req, timeout=30) as r:
+            products = json.load(r)["products"]
+        if not products:
+            break
+        for p in products:
+            if not any(v.get("available") for v in p.get("variants", [])):
+                continue
+            name = p["title"]
+            name = re.sub(r"\s*'[^']*'.*$", "", name)     # strip cultivars
+            name = re.sub(r'\s*\([^)]*\).*$', '', name)   # strip descriptors like (seed grown)
+            name = re.sub(r'\s+var\.\s+\S+.*$', '', name) # strip var.
+            name = name.strip()
+            gs = genus_species(name)
+            if len(gs.split()) >= 2 and gs not in seen:
+                seen.add(gs)
+                result.append(gs)
+        if len(products) < 250:
+            break
+        page += 1
+        time.sleep(1)
+    return result
+
+
 SCRAPERS = {
-    "oaktown": scrape_oaktown,
-    "sutro":   scrape_sutro,
+    "oaktown":    scrape_oaktown,
+    "sutro":      scrape_sutro,
+    "heronshead": scrape_heronshead,
 }
 
 
@@ -86,7 +123,21 @@ def main():
     with open(DATA_DIR / "sf_natives.csv") as f:
         sf_natives = {line.strip() for line in f if line.strip()}
 
-    by_species = {}
+    # Load previous inventory so failed nurseries keep their last-known data
+    inv_path = DATA_DIR / "nursery_inventory.json"
+    prev_by_species: dict = {}
+    if inv_path.exists():
+        with open(inv_path) as f:
+            prev_by_species = json.load(f).get("bySpecies", {})
+
+    # Build a reverse index: nursery_id → set of species it contributed previously
+    prev_by_nursery: dict[str, set] = {}
+    for gs, ids in prev_by_species.items():
+        for nid in ids:
+            prev_by_nursery.setdefault(nid, set()).add(gs)
+
+    succeeded: set[str] = set()
+    new_by_nursery: dict[str, set] = {}
 
     for nursery_id, info in nurseries.items():
         scraper = SCRAPERS.get(nursery_id)
@@ -95,24 +146,28 @@ def main():
         print(f"Scraping {info['name']} ...", flush=True)
         try:
             species = scraper(info["inventoryUrl"])
-            matched = 0
-            for gs in species:
-                if gs in sf_natives:
-                    by_species.setdefault(gs, []).append(nursery_id)
-                    matched += 1
-            print(f"  {len(species)} unique species, {matched} SF native matches")
+            matched = {gs for gs in species if gs in sf_natives}
+            new_by_nursery[nursery_id] = matched
+            succeeded.add(nursery_id)
+            print(f"  {len(species)} unique species, {len(matched)} SF native matches")
         except Exception as exc:
-            print(f"  ERROR: {exc}")
+            print(f"  ERROR: {exc} — keeping previous data")
+            new_by_nursery[nursery_id] = prev_by_nursery.get(nursery_id, set())
+
+    # Rebuild bySpecies index
+    by_species: dict[str, list] = {}
+    for nursery_id, species_set in new_by_nursery.items():
+        for gs in species_set:
+            by_species.setdefault(gs, []).append(nursery_id)
 
     inventory = {
         "lastUpdated": date.today().isoformat(),
         "bySpecies": dict(sorted(by_species.items())),
     }
 
-    out = DATA_DIR / "nursery_inventory.json"
-    with open(out, "w") as f:
+    with open(inv_path, "w") as f:
         json.dump(inventory, f, indent=2)
-    print(f"Wrote {len(by_species)} species to {out}")
+    print(f"Wrote {len(by_species)} species to {inv_path}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds Heron's Head Nursery (Bayview/SF) and makes the nightly scraper more resilient.

## Changes

### New nursery
- `nurseries.json` — adds `heronshead` (98 Jennings St., SF 94124; (415) 510-2500)
- `scrape_heronshead()` — uses Shopify's `/products.json` API with pagination; keeps only variants with `available: true`; strips cultivar names and parenthetical descriptors like `(seed grown)`
- 65 SF native matches from 130 in-stock unique species

### Scraper resilience
- `main()` now loads the previous `nursery_inventory.json` before scraping; if a nursery returns an error (e.g. transient 503), it falls back to its last-known species list rather than dropping it entirely

### Total
117 SF native species across 3 nurseries (Oaktown 89, Heron's Head 65, Sutro 9 — with overlap)

https://claude.ai/code/session_01LpMVNvRqM9umUaULcmfXHe

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpMVNvRqM9umUaULcmfXHe)_