### PR TITLE
Fix nursery tag pills invisible (undefined CSS variable)

### DIFF
--- a/sf-parks-biodiversity/style.css
+++ b/sf-parks-biodiversity/style.css
@@ -672,7 +672,7 @@ html, body {
 .nursery-tag {
   font-size: 0.68rem; font-weight: 500;
   padding: 2px 7px; border-radius: 10px;
-  background: var(--bg-body); border: 1px solid var(--border-soft);
+  background: var(--bg-panel); border: 1px solid var(--border);
   color: var(--text-mid);
 }
 .nursery-card-address, .nursery-card-phone {


### PR DESCRIPTION
One-line CSS fix: `--bg-body` was used in `.nursery-tag` but was never defined, causing tag backgrounds to be transparent and the pills to be invisible. Replaced with `--bg-panel` (white) and `--border` so they render as clearly visible white pills on the beige nursery card.

https://claude.ai/code/session_01LpMVNvRqM9umUaULcmfXHe

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpMVNvRqM9umUaULcmfXHe)_