### PR TITLE
Fix SF natives toggle button

### DIFF
--- a/sf-parks-biodiversity/app.js
+++ b/sf-parks-biodiversity/app.js
@@ -428,7 +428,7 @@ function toggleNativeMode() {
   if (state.selectedId) {
     const detail  = state.detailCache[state.selectedId];
     const feature = state.parks.find(f => pid(f) === state.selectedId);
-    if (detail?.species && feature) renderSidebar(feature, detail);
+    if (detail && feature) renderSidebar(feature, detail);
   }
 }
 

--- a/sf-parks-biodiversity/index.html
+++ b/sf-parks-biodiversity/index.html
@@ -26,7 +26,7 @@
         </div>
         <div id="native-filters">
           <div class="native-btn-row">
-            <button id="natives-btn" class="native-btn">🌿 SF Natives</button>
+            <button id="natives-btn" class="native-btn">show only natives</button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Fix sidebar not updating when toggling native mode: `detail?.species && feature` was blocking `renderSidebar` from running while species are still loading (null), so the park header count never updated to reflect the native filter. Changed to `detail && feature` so the sidebar re-renders immediately on toggle.
- Rename button from "🌿 SF Natives" to "show only natives" for clarity.

https://claude.ai/code/session_01LpMVNvRqM9umUaULcmfXHe

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpMVNvRqM9umUaULcmfXHe)_