### PR TITLE
Rankings: stable "Total species" column

### DIFF
--- a/sf-parks-biodiversity/app.js
+++ b/sf-parks-biodiversity/app.js
@@ -428,7 +428,7 @@ function toggleNativeMode() {
   if (state.selectedId) {
     const detail  = state.detailCache[state.selectedId];
     const feature = state.parks.find(f => pid(f) === state.selectedId);
-    if (detail?.species && feature) renderSidebar(feature, detail);
+    if (detail && feature) renderSidebar(feature, detail);
   }
 }
 

--- a/sf-parks-biodiversity/app.js
+++ b/sf-parks-biodiversity/app.js
@@ -382,15 +382,12 @@ function renderRankings() {
   const mode = state.nativeMode;
   entries.sort(([, a], [, b]) => buildSortVal(b, col, mode) - buildSortVal(a, col, mode));
 
-  const thSp = document.getElementById('th-species');
-  if (thSp) thSp.textContent = mode === 'sf' ? 'SF Native spp' : 'Species';
-
   body.innerHTML = entries.map(([id, d], i) => {
     const name  = state.summary[id]?.name ?? id;
     const sel   = state.selectedId === id ? 'row-selected' : '';
     const n     = v => v != null ? v.toLocaleString() : '–';
     const cats  = mode === 'sf' ? d.sf_native_cats : d.cats;
-    const total = mode === 'sf' ? d.sfNativeCount  : d.total;
+    const total = d.total;
     return `<tr class="${sel}" data-pid="${esc(id)}">
       <td class="td-rank">${i + 1}</td>
       <td class="td-name" title="${esc(name)}">${esc(name)}</td>

--- a/sf-parks-biodiversity/index.html
+++ b/sf-parks-biodiversity/index.html
@@ -72,7 +72,7 @@
               <tr>
                 <th class="th-rank">#</th>
                 <th class="th-name">Park / Natural Area</th>
-                <th class="th-num sortable" data-col="total" id="th-species">Species</th>
+                <th class="th-num sortable" data-col="total">Total species</th>
                 <th class="th-num sortable" data-col="Plantae">🌿 Plants</th>
                 <th class="th-num sortable" data-col="Aves">🐦 Birds</th>
                 <th class="th-num sortable" data-col="Insecta">🦋 Insects</th>

--- a/sf-parks-biodiversity/index.html
+++ b/sf-parks-biodiversity/index.html
@@ -26,7 +26,7 @@
         </div>
         <div id="native-filters">
           <div class="native-btn-row">
-            <button id="natives-btn" class="native-btn">🌿 SF Natives</button>
+            <button id="natives-btn" class="native-btn">show only natives</button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Remove the dynamic column header that switched between "Species" and "SF Native spp" depending on native mode — a column's meaning shouldn't change silently based on UI state.
- Rename the `<th>` to "Total species" and always display `d.total` in that cell regardless of mode.
- The ranking *order* still uses `sfNativeCount` when native mode is on, so native-rich parks still surface to the top — the rank position communicates the native richness, the column just always tells you the unambiguous total.
- Removed the now-unused `id="th-species"` attribute and the JS that targeted it.

https://claude.ai/code/session_01LpMVNvRqM9umUaULcmfXHe

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpMVNvRqM9umUaULcmfXHe)_