### PR TITLE
SF Grass Identifier: multi-select OR filters

### DIFF
--- a/sf-grass-identifier/data/grasses.json
+++ b/sf-grass-identifier/data/grasses.json
@@ -24,7 +24,12 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/254236867/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/254236867/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/254236867/medium.jpg",
+    "anther_count": 3,
+    "lemma_surface": "glabrous",
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 14.0,
+    "spikelet_length_mm_max": 25.0
   },
   {
     "inat_id": 64140,
@@ -46,7 +51,10 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/55523828/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/55523828/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/55523828/medium.jpg",
+    "auricles": true,
+    "anther_count": 6,
+    "spikelet_compression": "lateral"
   },
   {
     "inat_id": 61068,
@@ -77,7 +85,12 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/518537870/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/518537870/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/518537870/medium.jpg",
+    "anther_count": 3,
+    "lemma_surface": "pubescent",
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 8.0,
+    "spikelet_length_mm_max": 10.0
   },
   {
     "inat_id": 52796,
@@ -107,7 +120,13 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/12852/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/12852/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/12852/medium.jpg",
+    "auricles": true,
+    "anther_count": 3,
+    "lemma_surface": "scabrous",
+    "spikelet_compression": "dorsiventral",
+    "spikelet_length_mm_min": 7.0,
+    "spikelet_length_mm_max": 11.0
   },
   {
     "inat_id": 52702,
@@ -138,7 +157,11 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/131068365/square.jpeg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/131068365/medium.jpeg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/131068365/medium.jpeg",
+    "anther_count": 2,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 45.0,
+    "spikelet_length_mm_max": 60.0
   },
   {
     "inat_id": 52703,
@@ -169,7 +192,11 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/130309776/square.jpeg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/130309776/medium.jpeg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/130309776/medium.jpeg",
+    "anther_count": 3,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 12.0,
+    "spikelet_length_mm_max": 22.0
   },
   {
     "inat_id": 58372,
@@ -196,7 +223,12 @@
     "establishment_means": "native",
     "native_to_ca": true,
     "photo_url": "https://static.inaturalist.org/photos/51439487/square.jpeg",
-    "photo_medium": "https://static.inaturalist.org/photos/51439487/medium.jpeg"
+    "photo_medium": "https://static.inaturalist.org/photos/51439487/medium.jpeg",
+    "leaf_blade_shape": "involute",
+    "anther_count": 3,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 6.0,
+    "spikelet_length_mm_max": 18.0
   },
   {
     "inat_id": 52808,
@@ -223,7 +255,13 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/119472992/square.jpeg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/119472992/medium.jpeg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/119472992/medium.jpeg",
+    "leaf_blade_shape": "flat",
+    "anther_count": 3,
+    "lemma_surface": "glabrous",
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 3.0,
+    "spikelet_length_mm_max": 10.0
   },
   {
     "inat_id": 52793,
@@ -252,7 +290,11 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/233046284/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/233046284/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/233046284/medium.jpg",
+    "anther_count": 3,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 4.0,
+    "spikelet_length_mm_max": 6.0
   },
   {
     "inat_id": 57197,
@@ -282,7 +324,11 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/4096256/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/4096256/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/4096256/medium.jpg",
+    "anther_count": 3,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 2.0,
+    "spikelet_length_mm_max": 3.0
   },
   {
     "inat_id": 165659,
@@ -313,7 +359,12 @@
     "establishment_means": "native",
     "native_to_ca": true,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/361771071/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/361771071/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/361771071/medium.jpg",
+    "leaf_blade_shape": "flat_or_involute",
+    "anther_count": 3,
+    "lemma_surface": "pubescent",
+    "spikelet_length_mm_min": 15.0,
+    "spikelet_length_mm_max": 25.0
   },
   {
     "inat_id": 52714,
@@ -340,7 +391,10 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/27335442/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/27335442/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/27335442/medium.jpg",
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 12.0,
+    "spikelet_length_mm_max": 15.0
   },
   {
     "inat_id": 57162,
@@ -367,7 +421,12 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/34264/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/34264/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/34264/medium.jpg",
+    "anther_count": 3,
+    "lemma_surface": "glabrous",
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 3.0,
+    "spikelet_length_mm_max": 5.0
   },
   {
     "inat_id": 52696,
@@ -398,7 +457,12 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/6259588/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/6259588/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/6259588/medium.jpg",
+    "anther_count": 3,
+    "lemma_surface": "scabrous",
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 16.0,
+    "spikelet_length_mm_max": 26.0
   },
   {
     "inat_id": 61067,
@@ -425,7 +489,13 @@
     "establishment_means": "native",
     "native_to_ca": true,
     "photo_url": "https://static.inaturalist.org/photos/158210072/square.jpg",
-    "photo_medium": "https://static.inaturalist.org/photos/158210072/medium.jpg"
+    "photo_medium": "https://static.inaturalist.org/photos/158210072/medium.jpg",
+    "leaf_blade_shape": "involute",
+    "anther_count": 3,
+    "lemma_surface": "pubescent",
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 15.0,
+    "spikelet_length_mm_max": 22.0
   },
   {
     "inat_id": 61071,
@@ -449,7 +519,11 @@
     "establishment_means": "native",
     "native_to_ca": true,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/468543/square.jpeg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/468543/medium.jpeg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/468543/medium.jpeg",
+    "anther_count": 3,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 6.0,
+    "spikelet_length_mm_max": 10.0
   },
   {
     "inat_id": 942779,
@@ -477,7 +551,12 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/4243775/square.JPG",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/4243775/medium.JPG"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/4243775/medium.JPG",
+    "leaf_blade_shape": "convolute",
+    "anther_count": 3,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 10.0,
+    "spikelet_length_mm_max": 16.0
   },
   {
     "inat_id": 57165,
@@ -506,7 +585,12 @@
     "establishment_means": "native",
     "native_to_ca": true,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/431713/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/431713/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/431713/medium.jpg",
+    "leaf_blade_shape": "flat_or_involute",
+    "anther_count": 3,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 15.0,
+    "spikelet_length_mm_max": 20.0
   },
   {
     "inat_id": 52720,
@@ -537,7 +621,10 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/103010705/square.jpeg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/103010705/medium.jpeg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/103010705/medium.jpeg",
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 5.0,
+    "spikelet_length_mm_max": 9.0
   },
   {
     "inat_id": 52694,
@@ -562,7 +649,11 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/12075346/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/12075346/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/12075346/medium.jpg",
+    "anther_count": 3,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 2.4,
+    "spikelet_length_mm_max": 3.1
   },
   {
     "inat_id": 68479,
@@ -592,7 +683,11 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/10693239/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/10693239/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/10693239/medium.jpg",
+    "auricles": true,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 7.5,
+    "spikelet_length_mm_max": 25.0
   },
   {
     "inat_id": 57173,
@@ -622,7 +717,12 @@
     "establishment_means": "native",
     "native_to_ca": true,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/148856992/square.jpeg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/148856992/medium.jpeg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/148856992/medium.jpeg",
+    "auricles": false,
+    "anther_count": 3,
+    "spikelet_compression": "dorsiventral",
+    "spikelet_length_mm_min": 10.0,
+    "spikelet_length_mm_max": 12.0
   },
   {
     "inat_id": 57192,
@@ -647,7 +747,12 @@
     "establishment_means": "native",
     "native_to_ca": true,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/839097/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/839097/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/839097/medium.jpg",
+    "anther_count": 3,
+    "lemma_surface": "pubescent",
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 5.0,
+    "spikelet_length_mm_max": 8.0
   },
   {
     "inat_id": 52698,
@@ -678,7 +783,11 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/268294240/square.jpeg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/268294240/medium.jpeg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/268294240/medium.jpeg",
+    "anther_count": 3,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 18.0,
+    "spikelet_length_mm_max": 28.0
   },
   {
     "inat_id": 60298,
@@ -700,7 +809,12 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/256038282/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/256038282/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/256038282/medium.jpg",
+    "leaf_blade_shape": "flat",
+    "anther_count": 3,
+    "spikelet_compression": "dorsiventral",
+    "spikelet_length_mm_min": 10.0,
+    "spikelet_length_mm_max": 20.0
   },
   {
     "inat_id": 52791,
@@ -731,7 +845,12 @@
     "establishment_means": "native",
     "native_to_ca": true,
     "photo_url": "https://static.inaturalist.org/photos/75985465/square.jpg",
-    "photo_medium": "https://static.inaturalist.org/photos/75985465/medium.jpg"
+    "photo_medium": "https://static.inaturalist.org/photos/75985465/medium.jpg",
+    "anther_count": 3,
+    "lemma_surface": "scabrous",
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 10.0,
+    "spikelet_length_mm_max": 20.0
   },
   {
     "inat_id": 60276,
@@ -762,7 +881,11 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/173722843/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/173722843/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/173722843/medium.jpg",
+    "anther_count": 3,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 16.0,
+    "spikelet_length_mm_max": 40.0
   },
   {
     "inat_id": 52801,
@@ -789,7 +912,11 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/238799434/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/238799434/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/238799434/medium.jpg",
+    "auricles": true,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 7.0,
+    "spikelet_length_mm_max": 20.0
   },
   {
     "inat_id": 64240,
@@ -816,7 +943,10 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/173109660/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/173109660/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/173109660/medium.jpg",
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 12.0,
+    "spikelet_length_mm_max": 18.0
   },
   {
     "inat_id": 57184,
@@ -843,7 +973,11 @@
     "establishment_means": "native",
     "native_to_ca": true,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/12614241/square.jpeg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/12614241/medium.jpeg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/12614241/medium.jpeg",
+    "leaf_blade_shape": "flat_or_involute",
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 6.0,
+    "spikelet_length_mm_max": 10.0
   },
   {
     "inat_id": 71142,
@@ -874,7 +1008,12 @@
     "establishment_means": "native",
     "native_to_ca": true,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/468548/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/468548/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/468548/medium.jpg",
+    "anther_count": 3,
+    "lemma_surface": "pubescent",
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 30.0,
+    "spikelet_length_mm_max": 40.0
   },
   {
     "inat_id": 57183,
@@ -901,7 +1040,11 @@
     "establishment_means": "native",
     "native_to_ca": true,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/42363755/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/42363755/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/42363755/medium.jpg",
+    "anther_count": 3,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 4.0,
+    "spikelet_length_mm_max": 6.0
   },
   {
     "inat_id": 57186,
@@ -928,7 +1071,11 @@
     "establishment_means": "native",
     "native_to_ca": true,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/6814579/square.jpeg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/6814579/medium.jpeg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/6814579/medium.jpeg",
+    "anther_count": 3,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 10.0,
+    "spikelet_length_mm_max": 12.0
   },
   {
     "inat_id": 47695,
@@ -971,7 +1118,13 @@
     "establishment_means": "native",
     "native_to_ca": true,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/399068532/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/399068532/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/399068532/medium.jpg",
+    "auricles": false,
+    "anther_count": 3,
+    "lemma_surface": "glabrous",
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 15.0,
+    "spikelet_length_mm_max": 45.0
   },
   {
     "inat_id": 61061,
@@ -999,7 +1152,11 @@
     "establishment_means": "native",
     "native_to_ca": true,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/33024046/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/33024046/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/33024046/medium.jpg",
+    "anther_count": 3,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 5.0,
+    "spikelet_length_mm_max": 14.0
   },
   {
     "inat_id": 61063,
@@ -1027,7 +1184,11 @@
     "establishment_means": "native",
     "native_to_ca": true,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/225985208/square.jpeg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/225985208/medium.jpeg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/225985208/medium.jpeg",
+    "anther_count": 3,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 4.5,
+    "spikelet_length_mm_max": 6.5
   },
   {
     "inat_id": 77136,
@@ -1057,7 +1218,12 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://static.inaturalist.org/photos/12954865/square.jpg",
-    "photo_medium": "https://static.inaturalist.org/photos/12954865/medium.jpg"
+    "photo_medium": "https://static.inaturalist.org/photos/12954865/medium.jpg",
+    "leaf_blade_shape": "flat_or_involute",
+    "anther_count": 1,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 7.0,
+    "spikelet_length_mm_max": 14.0
   },
   {
     "inat_id": 165660,
@@ -1088,7 +1254,11 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/16420772/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/16420772/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/16420772/medium.jpg",
+    "anther_count": 3,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 5.0,
+    "spikelet_length_mm_max": 10.5
   },
   {
     "inat_id": 58371,
@@ -1115,7 +1285,11 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/583408803/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/583408803/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/583408803/medium.jpg",
+    "leaf_blade_shape": "flat",
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 2.0,
+    "spikelet_length_mm_max": 2.5
   },
   {
     "inat_id": 64161,
@@ -1145,7 +1319,12 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/127585014/square.jpeg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/127585014/medium.jpeg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/127585014/medium.jpeg",
+    "auricles": true,
+    "anther_count": 3,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 10.0,
+    "spikelet_length_mm_max": 15.0
   },
   {
     "inat_id": 77140,
@@ -1176,7 +1355,12 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/381229715/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/381229715/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/381229715/medium.jpg",
+    "leaf_blade_shape": "flat_or_involute",
+    "anther_count": 1,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 6.0,
+    "spikelet_length_mm_max": 8.0
   },
   {
     "inat_id": 52804,
@@ -1203,7 +1387,12 @@
     "establishment_means": "native",
     "native_to_ca": true,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/593910/square.JPG",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/593910/medium.JPG"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/593910/medium.JPG",
+    "anther_count": 3,
+    "lemma_surface": "pubescent",
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 4.0,
+    "spikelet_length_mm_max": 6.0
   },
   {
     "inat_id": 76639,
@@ -1230,7 +1419,12 @@
     "establishment_means": "native",
     "native_to_ca": true,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/108225556/square.jpeg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/108225556/medium.jpeg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/108225556/medium.jpeg",
+    "leaf_blade_shape": "flat_or_involute",
+    "anther_count": 3,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 4.0,
+    "spikelet_length_mm_max": 6.0
   },
   {
     "inat_id": 52802,
@@ -1257,7 +1451,11 @@
     "establishment_means": "native",
     "native_to_ca": true,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/37740773/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/37740773/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/37740773/medium.jpg",
+    "anther_count": 3,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 3.5,
+    "spikelet_length_mm_max": 7.0
   },
   {
     "inat_id": 57169,
@@ -1287,7 +1485,12 @@
     "establishment_means": "native",
     "native_to_ca": true,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/17802550/square.jpeg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/17802550/medium.jpeg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/17802550/medium.jpeg",
+    "leaf_blade_shape": "involute",
+    "anther_count": 3,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 10.0,
+    "spikelet_length_mm_max": 15.0
   },
   {
     "inat_id": 58379,
@@ -1316,7 +1519,12 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://static.inaturalist.org/photos/426312020/square.jpg",
-    "photo_medium": "https://static.inaturalist.org/photos/426312020/medium.jpg"
+    "photo_medium": "https://static.inaturalist.org/photos/426312020/medium.jpg",
+    "anther_count": 3,
+    "lemma_surface": "scabrous",
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 4.0,
+    "spikelet_length_mm_max": 8.0
   },
   {
     "inat_id": 60294,
@@ -1340,7 +1548,11 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/28241281/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/28241281/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/28241281/medium.jpg",
+    "anther_count": 3,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 4.0,
+    "spikelet_length_mm_max": 6.0
   },
   {
     "inat_id": 164677,
@@ -1367,7 +1579,11 @@
     "establishment_means": "native",
     "native_to_ca": true,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/278231517/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/278231517/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/278231517/medium.jpg",
+    "leaf_blade_shape": "involute",
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 12.0,
+    "spikelet_length_mm_max": 15.0
   },
   {
     "inat_id": 164708,
@@ -1395,7 +1611,10 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/55763040/square.jpeg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/55763040/medium.jpeg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/55763040/medium.jpeg",
+    "auricles": true,
+    "anther_count": 3,
+    "spikelet_compression": "lateral"
   },
   {
     "inat_id": 60295,
@@ -1420,7 +1639,10 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/321349275/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/321349275/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/321349275/medium.jpg",
+    "spikelet_compression": "dorsiventral",
+    "spikelet_length_mm_min": 2.8,
+    "spikelet_length_mm_max": 3.8
   },
   {
     "inat_id": 75475,
@@ -1441,7 +1663,11 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/73830271/square.jpeg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/73830271/medium.jpeg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/73830271/medium.jpeg",
+    "anther_count": 2,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 7.0,
+    "spikelet_length_mm_max": 9.5
   },
   {
     "inat_id": 77138,
@@ -1471,7 +1697,12 @@
     "establishment_means": "native",
     "native_to_ca": true,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/74242227/square.jpeg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/74242227/medium.jpeg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/74242227/medium.jpeg",
+    "leaf_blade_shape": "flat_or_involute",
+    "lemma_surface": "scabrous",
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 1.0,
+    "spikelet_length_mm_max": 9.0
   },
   {
     "inat_id": 430581,
@@ -1496,7 +1727,12 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/6748173/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/6748173/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/6748173/medium.jpg",
+    "leaf_blade_shape": "convolute",
+    "anther_count": 3,
+    "spikelet_compression": "dorsiventral",
+    "spikelet_length_mm_min": 16.0,
+    "spikelet_length_mm_max": 40.0
   },
   {
     "inat_id": 524183,
@@ -1527,7 +1763,9 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/68985268/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/68985268/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/68985268/medium.jpg",
+    "leaf_blade_shape": "flat",
+    "spikelet_compression": "dorsiventral"
   },
   {
     "inat_id": 52707,
@@ -1558,7 +1796,11 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/127689145/square.jpeg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/127689145/medium.jpeg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/127689145/medium.jpeg",
+    "anther_count": 3,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 15.0,
+    "spikelet_length_mm_max": 45.0
   },
   {
     "inat_id": 58387,
@@ -1587,7 +1829,10 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/78416044/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/78416044/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/78416044/medium.jpg",
+    "spikelet_compression": "dorsiventral",
+    "spikelet_length_mm_min": 4.5,
+    "spikelet_length_mm_max": 6.5
   },
   {
     "inat_id": 165656,
@@ -1618,7 +1863,10 @@
     "establishment_means": null,
     "native_to_ca": false,
     "photo_url": "https://static.inaturalist.org/photos/185504835/square.jpg",
-    "photo_medium": "https://static.inaturalist.org/photos/185504835/medium.jpg"
+    "photo_medium": "https://static.inaturalist.org/photos/185504835/medium.jpg",
+    "anther_count": 3,
+    "spikelet_length_mm_min": 6.0,
+    "spikelet_length_mm_max": 10.0
   },
   {
     "inat_id": 772992,
@@ -1645,7 +1893,13 @@
     "establishment_means": "native",
     "native_to_ca": true,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/49344182/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/49344182/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/49344182/medium.jpg",
+    "leaf_blade_shape": "flat_or_involute",
+    "anther_count": 3,
+    "lemma_surface": "glabrous",
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 8.0,
+    "spikelet_length_mm_max": 25.0
   },
   {
     "inat_id": 52692,
@@ -1672,7 +1926,10 @@
     "establishment_means": "native",
     "native_to_ca": true,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/317775663/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/317775663/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/317775663/medium.jpg",
+    "leaf_blade_shape": "involute",
+    "anther_count": 3,
+    "spikelet_compression": "lateral"
   },
   {
     "inat_id": 57188,
@@ -1697,7 +1954,12 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/244905231/square.jpeg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/244905231/medium.jpeg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/244905231/medium.jpeg",
+    "anther_count": 3,
+    "lemma_surface": "pubescent",
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 4.5,
+    "spikelet_length_mm_max": 7.5
   },
   {
     "inat_id": 48448,
@@ -1722,7 +1984,9 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://static.inaturalist.org/photos/88716363/square.jpeg",
-    "photo_medium": "https://static.inaturalist.org/photos/88716363/medium.jpeg"
+    "photo_medium": "https://static.inaturalist.org/photos/88716363/medium.jpeg",
+    "anther_count": 3,
+    "spikelet_compression": "dorsiventral"
   },
   {
     "inat_id": 57181,
@@ -1749,7 +2013,13 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/273100623/square.jpeg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/273100623/medium.jpeg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/273100623/medium.jpeg",
+    "auricles": false,
+    "anther_count": 3,
+    "lemma_surface": "glabrous",
+    "spikelet_compression": "dorsiventral",
+    "spikelet_length_mm_min": 3.0,
+    "spikelet_length_mm_max": 5.0
   },
   {
     "inat_id": 57182,
@@ -1779,7 +2049,12 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/76716288/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/76716288/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/76716288/medium.jpg",
+    "auricles": true,
+    "anther_count": 3,
+    "spikelet_compression": "dorsiventral",
+    "spikelet_length_mm_min": 10.0,
+    "spikelet_length_mm_max": 15.0
   },
   {
     "inat_id": 58376,
@@ -1807,7 +2082,12 @@
     "establishment_means": "native",
     "native_to_ca": true,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/77063444/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/77063444/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/77063444/medium.jpg",
+    "auricles": true,
+    "lemma_surface": "scabrous",
+    "spikelet_compression": "dorsiventral",
+    "spikelet_length_mm_min": 6.0,
+    "spikelet_length_mm_max": 10.0
   },
   {
     "inat_id": 59210,
@@ -1838,7 +2118,12 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/32783733/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/32783733/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/32783733/medium.jpg",
+    "anther_count": 3,
+    "lemma_surface": "glabrous",
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 15.0,
+    "spikelet_length_mm_max": 30.0
   },
   {
     "inat_id": 164673,
@@ -1865,7 +2150,11 @@
     "establishment_means": "native",
     "native_to_ca": true,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/66056/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/66056/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/66056/medium.jpg",
+    "lemma_surface": "glabrous",
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 10.0,
+    "spikelet_length_mm_max": 15.0
   },
   {
     "inat_id": 430578,
@@ -1890,7 +2179,12 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/1742834/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/1742834/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/1742834/medium.jpg",
+    "leaf_blade_shape": "flat",
+    "anther_count": 3,
+    "spikelet_compression": "dorsiventral",
+    "spikelet_length_mm_min": 40.0,
+    "spikelet_length_mm_max": 70.0
   },
   {
     "inat_id": 1550239,
@@ -1929,7 +2223,12 @@
     "establishment_means": null,
     "native_to_ca": false,
     "photo_url": "https://static.inaturalist.org/photos/123270171/square.jpeg",
-    "photo_medium": "https://static.inaturalist.org/photos/123270171/medium.jpeg"
+    "photo_medium": "https://static.inaturalist.org/photos/123270171/medium.jpeg",
+    "leaf_blade_shape": "involute",
+    "anther_count": 3,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 2.5,
+    "spikelet_length_mm_max": 3.5
   },
   {
     "inat_id": 59099,
@@ -1959,7 +2258,11 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/22985404/square.jpeg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/22985404/medium.jpeg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/22985404/medium.jpeg",
+    "anther_count": 3,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 2.5,
+    "spikelet_length_mm_max": 3.0
   },
   {
     "inat_id": 64017,
@@ -1986,7 +2289,11 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/627890218/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/627890218/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/627890218/medium.jpg",
+    "anther_count": 3,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 8.0,
+    "spikelet_length_mm_max": 15.0
   },
   {
     "inat_id": 64144,
@@ -2013,7 +2320,11 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/1816527/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/1816527/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/1816527/medium.jpg",
+    "anther_count": 3,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 1.75,
+    "spikelet_length_mm_max": 2.0
   },
   {
     "inat_id": 325917,
@@ -2043,7 +2354,12 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/481373804/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/481373804/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/481373804/medium.jpg",
+    "anther_count": 3,
+    "lemma_surface": "pubescent",
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 20.0,
+    "spikelet_length_mm_max": 30.0
   },
   {
     "inat_id": 1199528,
@@ -2083,7 +2399,12 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/51273833/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/51273833/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/51273833/medium.jpg",
+    "anther_count": 3,
+    "lemma_surface": "scabrous",
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 22.0,
+    "spikelet_length_mm_max": 27.0
   },
   {
     "inat_id": 57167,
@@ -2112,7 +2433,12 @@
     "establishment_means": "native",
     "native_to_ca": true,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/40193265/square.jpeg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/40193265/medium.jpeg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/40193265/medium.jpeg",
+    "auricles": true,
+    "lemma_surface": "scabrous",
+    "spikelet_compression": "dorsiventral",
+    "spikelet_length_mm_min": 8.0,
+    "spikelet_length_mm_max": 10.0
   },
   {
     "inat_id": 57191,
@@ -2137,7 +2463,12 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/528247421/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/528247421/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/528247421/medium.jpg",
+    "anther_count": 3,
+    "lemma_surface": "pubescent",
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 6.0,
+    "spikelet_length_mm_max": 10.0
   },
   {
     "inat_id": 58369,
@@ -2168,7 +2499,11 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/58336299/square.jpeg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/58336299/medium.jpeg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/58336299/medium.jpeg",
+    "anther_count": 3,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 10.0,
+    "spikelet_length_mm_max": 25.0
   },
   {
     "inat_id": 58389,
@@ -2194,7 +2529,10 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/55135120/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/55135120/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/55135120/medium.jpg",
+    "spikelet_compression": "dorsiventral",
+    "spikelet_length_mm_min": 3.0,
+    "spikelet_length_mm_max": 10.0
   },
   {
     "inat_id": 61070,
@@ -2221,7 +2559,12 @@
     "establishment_means": "native",
     "native_to_ca": true,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/38089095/square.jpeg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/38089095/medium.jpeg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/38089095/medium.jpeg",
+    "leaf_blade_shape": "flat",
+    "anther_count": 3,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 6.0,
+    "spikelet_length_mm_max": 8.0
   },
   {
     "inat_id": 69931,
@@ -2248,7 +2591,11 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/527929316/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/527929316/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/527929316/medium.jpg",
+    "anther_count": 3,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 2.0,
+    "spikelet_length_mm_max": 3.0
   },
   {
     "inat_id": 71140,
@@ -2285,7 +2632,9 @@
     "establishment_means": null,
     "native_to_ca": false,
     "photo_url": "https://static.inaturalist.org/photos/16748012/square.jpg",
-    "photo_medium": "https://static.inaturalist.org/photos/16748012/medium.jpg"
+    "photo_medium": "https://static.inaturalist.org/photos/16748012/medium.jpg",
+    "anther_count": 2,
+    "spikelet_compression": "lateral"
   },
   {
     "inat_id": 75903,
@@ -2312,7 +2661,12 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/449379438/square.jpeg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/449379438/medium.jpeg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/449379438/medium.jpeg",
+    "anther_count": 3,
+    "lemma_surface": "glabrous",
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 15.0,
+    "spikelet_length_mm_max": 25.0
   },
   {
     "inat_id": 75912,
@@ -2342,7 +2696,12 @@
     "establishment_means": null,
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/135599191/square.jpeg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/135599191/medium.jpeg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/135599191/medium.jpeg",
+    "anther_count": 3,
+    "lemma_surface": "glabrous",
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 20.0,
+    "spikelet_length_mm_max": 40.0
   },
   {
     "inat_id": 79021,
@@ -2372,7 +2731,12 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/8346266/square.jpeg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/8346266/medium.jpeg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/8346266/medium.jpeg",
+    "auricles": true,
+    "anther_count": 3,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 12.0,
+    "spikelet_length_mm_max": 15.0
   },
   {
     "inat_id": 79068,
@@ -2397,7 +2761,11 @@
     "establishment_means": "native",
     "native_to_ca": true,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/50707544/square.jpeg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/50707544/medium.jpeg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/50707544/medium.jpeg",
+    "anther_count": 3,
+    "spikelet_compression": "dorsiventral",
+    "spikelet_length_mm_min": 1.5,
+    "spikelet_length_mm_max": 8.0
   },
   {
     "inat_id": 204259,
@@ -2427,7 +2795,12 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/4194440/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/4194440/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/4194440/medium.jpg",
+    "anther_count": 3,
+    "lemma_surface": "glabrous",
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 20.0,
+    "spikelet_length_mm_max": 30.0
   },
   {
     "inat_id": 431011,
@@ -2457,7 +2830,13 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/123857131/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/123857131/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/123857131/medium.jpg",
+    "auricles": true,
+    "anther_count": 3,
+    "lemma_surface": "pubescent",
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 6.0,
+    "spikelet_length_mm_max": 8.0
   },
   {
     "inat_id": 773038,
@@ -2481,7 +2860,11 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://static.inaturalist.org/photos/144474552/square.jpeg",
-    "photo_medium": "https://static.inaturalist.org/photos/144474552/medium.jpeg"
+    "photo_medium": "https://static.inaturalist.org/photos/144474552/medium.jpeg",
+    "anther_count": 3,
+    "spikelet_compression": "lateral",
+    "spikelet_length_mm_min": 2.5,
+    "spikelet_length_mm_max": 4.0
   },
   {
     "inat_id": 1477514,
@@ -2508,6 +2891,11 @@
     "establishment_means": "introduced",
     "native_to_ca": false,
     "photo_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/283540454/square.jpg",
-    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/283540454/medium.jpg"
+    "photo_medium": "https://inaturalist-open-data.s3.amazonaws.com/photos/283540454/medium.jpg",
+    "leaf_blade_shape": "involute",
+    "anther_count": 3,
+    "spikelet_compression": "dorsiventral",
+    "spikelet_length_mm_min": 5.0,
+    "spikelet_length_mm_max": 7.0
   }
 ]

--- a/sf-grass-identifier/enrich_morph.py
+++ b/sf-grass-identifier/enrich_morph.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+Enrich grasses.json with additional GrassBase morphological fields
+not extracted in the original fetch_data.py run.
+
+New fields added per species (where available):
+  leaf_blade_shape    – flat | involute | folded | convolute
+  auricles            – True / False
+  anther_count        – 1 | 2 | 3
+  lemma_surface       – glabrous | pubescent | scabrous | hairy
+  spikelet_compression – lateral | dorsiventral
+  spikelet_length_mm_min / spikelet_length_mm_max
+  glumes              – description string (short / as long as / exceeding florets)
+  lemma_shape         – lanceolate | ovate | oblong | elliptic etc.
+"""
+import json, time, re, os, sys, urllib.request
+
+DATA_DIR  = os.path.join(os.path.dirname(__file__), 'data')
+GRASSES   = os.path.join(DATA_DIR, 'grasses.json')
+DELAY     = 1.8
+
+NEW_FIELDS = [
+    'leaf_blade_shape', 'auricles', 'anther_count',
+    'lemma_surface', 'spikelet_compression',
+    'spikelet_length_mm_min', 'spikelet_length_mm_max',
+]
+
+def fetch_html(url, retries=4):
+    for attempt in range(retries):
+        try:
+            time.sleep(DELAY * (1 + attempt * 0.5))
+            req = urllib.request.Request(url, headers={
+                'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)',
+                'Accept': 'text/html',
+            })
+            with urllib.request.urlopen(req, timeout=30) as r:
+                return r.read().decode('utf-8', errors='replace')
+        except Exception as e:
+            if attempt == retries - 1:
+                raise
+            wait = 2 ** attempt
+            print(f'  retry in {wait}s ({e})', file=sys.stderr)
+            time.sleep(wait)
+
+def extract_grassbase_text(html):
+    html = re.sub(r'<script[^>]*>.*?</script>', '', html, flags=re.DOTALL)
+    html = re.sub(r'<style[^>]*>.*?</style>',  '', html, flags=re.DOTALL)
+    text = re.sub(r'<[^>]+>', ' ', html)
+    text = re.sub(r'\s+', ' ', text).strip()
+    idx = text.find('GrassBase')
+    if idx < 0:
+        return None
+    return text[idx:idx+6000]   # wider window than before
+
+def parse_new_fields(gb):
+    feats = {}
+
+    # ── Leaf blade shape ──────────────────────────────────────────────────────
+    # GrassBase: "Leaf-blades flat, or involute; ..."
+    lb_section = ''
+    m = re.search(r'(Leaf.blades?[^;.]{0,200})', gb, re.I)
+    if m:
+        lb_section = m.group(1)
+    if re.search(r'\bflat\b', lb_section, re.I) and not re.search(r'\binvolute\b', lb_section, re.I):
+        feats['leaf_blade_shape'] = 'flat'
+    elif re.search(r'\binvolute\b', lb_section, re.I) and not re.search(r'\bflat\b', lb_section, re.I):
+        feats['leaf_blade_shape'] = 'involute'
+    elif re.search(r'\bflat\b', lb_section, re.I) and re.search(r'\binvolute\b', lb_section, re.I):
+        feats['leaf_blade_shape'] = 'flat_or_involute'
+    elif re.search(r'\bfolded\b', lb_section, re.I):
+        feats['leaf_blade_shape'] = 'folded'
+    elif re.search(r'\bconvolute\b', lb_section, re.I):
+        feats['leaf_blade_shape'] = 'convolute'
+
+    # ── Auricles ──────────────────────────────────────────────────────────────
+    if re.search(r'\bauricles?\b', gb, re.I):
+        # "auricles absent" vs any positive mention
+        if re.search(r'auricles?\s+absent', gb, re.I):
+            feats['auricles'] = False
+        else:
+            feats['auricles'] = True
+
+    # ── Anther count ──────────────────────────────────────────────────────────
+    # GrassBase format: "Anthers 3" or "Anthers 3; 0.7–1.2 mm long"
+    m = re.search(r'Anthers?\s+(\d)\b', gb, re.I)
+    if m:
+        feats['anther_count'] = int(m.group(1))
+
+    # ── Lemma surface ─────────────────────────────────────────────────────────
+    # GrassBase: "Lemma surface glabrous, or pubescent; ..."
+    m = re.search(r'Lemma surface\s+([^;.]{0,80})', gb, re.I)
+    if m:
+        surf = m.group(1)
+        if re.search(r'\bglabrous\b', surf, re.I):
+            feats['lemma_surface'] = 'glabrous'
+        elif re.search(r'\bpubescent\b', surf, re.I):
+            feats['lemma_surface'] = 'pubescent'
+        elif re.search(r'\bscabrous\b', surf, re.I):
+            feats['lemma_surface'] = 'scabrous'
+        elif re.search(r'\bhairy\b', surf, re.I):
+            feats['lemma_surface'] = 'hairy'
+        elif re.search(r'\bsmooth\b', surf, re.I):
+            feats['lemma_surface'] = 'glabrous'
+
+    # ── Spikelet compression ──────────────────────────────────────────────────
+    if re.search(r'laterally\s+compressed', gb, re.I):
+        feats['spikelet_compression'] = 'lateral'
+    elif re.search(r'dorsiventrally\s+compressed|dorsally\s+compressed', gb, re.I):
+        feats['spikelet_compression'] = 'dorsiventral'
+
+    # ── Spikelet length ───────────────────────────────────────────────────────
+    m = re.search(r'Spikelets?[^.]*?(\d+(?:\.\d+)?)[–\-](\d+(?:\.\d+)?)\s*mm\s*(long|in\s+length)', gb, re.I)
+    if m:
+        feats['spikelet_length_mm_min'] = float(m.group(1))
+        feats['spikelet_length_mm_max'] = float(m.group(2))
+
+    return feats
+
+
+def needs_enrichment(sp):
+    return any(sp.get(f) is None for f in NEW_FIELDS)
+
+
+species = json.load(open(GRASSES))
+total = len(species)
+updated = 0
+
+for i, sp in enumerate(species):
+    ipni_id = sp.get('ipni_id')
+    if not ipni_id:
+        print(f'[{i+1}/{total}] {sp["sci_name"]}: no IPNI id, skip')
+        continue
+
+    if not needs_enrichment(sp):
+        print(f'[{i+1}/{total}] {sp["sci_name"]}: already enriched')
+        continue
+
+    print(f'[{i+1}/{total}] {sp["sci_name"]}', end='', flush=True)
+    try:
+        url = f'https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:{ipni_id}/general-information'
+        html = fetch_html(url)
+        gb = extract_grassbase_text(html) if html else None
+        if gb:
+            new = parse_new_fields(gb)
+            sp.update(new)
+            found = [k for k in NEW_FIELDS if sp.get(k) is not None]
+            print(f'  +{found}')
+            updated += 1
+        else:
+            print('  no GrassBase section')
+    except Exception as e:
+        print(f'  ERROR: {e}')
+
+    # checkpoint every 10
+    if (i + 1) % 10 == 0:
+        json.dump(species, open(GRASSES, 'w'), indent=2)
+        print(f'  [checkpoint {i+1}]')
+
+json.dump(species, open(GRASSES, 'w'), indent=2)
+print(f'\nDone. {updated}/{total} species enriched.')

--- a/sf-grass-identifier/fetch_data.py
+++ b/sf-grass-identifier/fetch_data.py
@@ -192,6 +192,58 @@ def parse_grassbase(html):
     else:
         feats['has_awns'] = False
 
+    # ── Leaf blade shape ──────────────────────────────────────────────────────
+    lb_section = ''
+    m = re.search(r'(Leaf.blades?[^;.]{0,200})', gb, re.I)
+    if m:
+        lb_section = m.group(1)
+    if re.search(r'\bflat\b', lb_section, re.I) and not re.search(r'\binvolute\b', lb_section, re.I):
+        feats['leaf_blade_shape'] = 'flat'
+    elif re.search(r'\binvolute\b', lb_section, re.I) and not re.search(r'\bflat\b', lb_section, re.I):
+        feats['leaf_blade_shape'] = 'involute'
+    elif re.search(r'\bflat\b', lb_section, re.I) and re.search(r'\binvolute\b', lb_section, re.I):
+        feats['leaf_blade_shape'] = 'flat_or_involute'
+    elif re.search(r'\bfolded\b', lb_section, re.I):
+        feats['leaf_blade_shape'] = 'folded'
+    elif re.search(r'\bconvolute\b', lb_section, re.I):
+        feats['leaf_blade_shape'] = 'convolute'
+
+    # ── Auricles ──────────────────────────────────────────────────────────────
+    if re.search(r'\bauricles?\b', gb, re.I):
+        feats['auricles'] = not bool(re.search(r'auricles?\s+absent', gb, re.I))
+
+    # ── Anther count ──────────────────────────────────────────────────────────
+    m = re.search(r'Anthers?\s+(\d)\b', gb, re.I)
+    if m:
+        feats['anther_count'] = int(m.group(1))
+
+    # ── Lemma surface ─────────────────────────────────────────────────────────
+    m = re.search(r'Lemma surface\s+([^;.]{0,80})', gb, re.I)
+    if m:
+        surf = m.group(1)
+        if re.search(r'\bglabrous\b', surf, re.I):
+            feats['lemma_surface'] = 'glabrous'
+        elif re.search(r'\bpubescent\b', surf, re.I):
+            feats['lemma_surface'] = 'pubescent'
+        elif re.search(r'\bscabrous\b', surf, re.I):
+            feats['lemma_surface'] = 'scabrous'
+        elif re.search(r'\bhairy\b', surf, re.I):
+            feats['lemma_surface'] = 'hairy'
+        elif re.search(r'\bsmooth\b', surf, re.I):
+            feats['lemma_surface'] = 'glabrous'
+
+    # ── Spikelet compression ──────────────────────────────────────────────────
+    if re.search(r'laterally\s+compressed', gb, re.I):
+        feats['spikelet_compression'] = 'lateral'
+    elif re.search(r'dorsiventrally\s+compressed|dorsally\s+compressed', gb, re.I):
+        feats['spikelet_compression'] = 'dorsiventral'
+
+    # ── Spikelet length ───────────────────────────────────────────────────────
+    m = re.search(r'Spikelets?[^.]*?(\d+(?:\.\d+)?)[–\-](\d+(?:\.\d+)?)\s*mm\s*(long|in\s+length)', gb, re.I)
+    if m:
+        feats['spikelet_length_mm_min'] = float(m.group(1))
+        feats['spikelet_length_mm_max'] = float(m.group(2))
+
     # Native range (not in GrassBase but appears earlier on page)
     m = re.search(r'native range[^.]*?is\s+([^.]+)', text, re.I)
     if m:

--- a/sf-grass-identifier/index.html
+++ b/sf-grass-identifier/index.html
@@ -408,6 +408,51 @@
       </div>
     </div>
 
+    <div class="filter-group">
+      <label class="group-label">Spikelet compression</label>
+      <div class="chip-row" id="f-compression">
+        <div class="chip" data-filter="spikelet_compression" data-value="lateral">Laterally compressed</div>
+        <div class="chip" data-filter="spikelet_compression" data-value="dorsiventral">Dorsiventrally compressed</div>
+      </div>
+    </div>
+
+    <div class="filter-group">
+      <label class="group-label">Anthers per floret <span class="multi-hint">multi-select</span></label>
+      <div class="chip-row" id="f-anthers" data-multi="true">
+        <div class="chip" data-filter="anther_count" data-value="1">1</div>
+        <div class="chip" data-filter="anther_count" data-value="2">2</div>
+        <div class="chip" data-filter="anther_count" data-value="3">3</div>
+      </div>
+    </div>
+
+    <div class="filter-group">
+      <label class="group-label">Lemma surface <span class="multi-hint">multi-select</span></label>
+      <div class="chip-row" id="f-lemma" data-multi="true">
+        <div class="chip" data-filter="lemma_surface" data-value="glabrous">Glabrous</div>
+        <div class="chip" data-filter="lemma_surface" data-value="pubescent">Pubescent</div>
+        <div class="chip" data-filter="lemma_surface" data-value="scabrous">Scabrous</div>
+      </div>
+    </div>
+
+    <div class="filter-group">
+      <label class="group-label">Leaf blade shape <span class="multi-hint">multi-select</span></label>
+      <div class="chip-row" id="f-blade-shape" data-multi="true">
+        <div class="chip" data-filter="leaf_blade_shape" data-value="flat">Flat</div>
+        <div class="chip" data-filter="leaf_blade_shape" data-value="flat_or_involute">Flat or involute</div>
+        <div class="chip" data-filter="leaf_blade_shape" data-value="involute">Involute (inrolled)</div>
+        <div class="chip" data-filter="leaf_blade_shape" data-value="folded">Folded</div>
+        <div class="chip" data-filter="leaf_blade_shape" data-value="convolute">Convolute</div>
+      </div>
+    </div>
+
+    <div class="filter-group">
+      <label class="group-label">Auricles</label>
+      <div class="chip-row" id="f-auricles">
+        <div class="chip" data-filter="auricles" data-value="true">Present</div>
+        <div class="chip" data-filter="auricles" data-value="false">Absent</div>
+      </div>
+    </div>
+
     <button id="clear-btn">Clear all filters</button>
   </aside>
 
@@ -432,6 +477,12 @@
           <th data-col="leaf_width_min_mm">Leaf width</th>
           <th data-col="height_min_cm">Height</th>
           <th data-col="caespitose">Habit</th>
+          <th data-col="spikelet_compression">Spikelet</th>
+          <th data-col="spikelet_length_mm_min">Spikelet length</th>
+          <th data-col="anther_count">Anthers</th>
+          <th data-col="lemma_surface">Lemma surface</th>
+          <th data-col="leaf_blade_shape">Blade shape</th>
+          <th data-col="auricles">Auricles</th>
           <th data-col="inat_obs_sf">SF obs.</th>
         </tr>
       </thead>
@@ -502,6 +553,10 @@ function scoreSpecies(sp, filters) {
   for (const [key, vals] of Object.entries(filters)) {
     // duration: annual_or_perennial matches either chip
     if (key === 'duration' && sp._durationBoth) { matched++; continue; }
+    // leaf_blade_shape: flat_or_involute matches either 'flat' or 'involute' chip
+    if (key === 'leaf_blade_shape' && sp.leaf_blade_shape === 'flat_or_involute') {
+      if (vals.has('flat') || vals.has('involute') || vals.has('flat_or_involute')) { matched++; continue; }
+    }
 
     const spVal = sp[key];
     // vals is a Set<string>; coerce species value to string for comparison,
@@ -510,6 +565,8 @@ function scoreSpecies(sp, filters) {
     for (const v of vals) {
       const filterVal = v === 'true' ? true : v === 'false' ? false : v;
       if (spVal === filterVal) { hit = true; break; }
+      // handle numeric species values vs string filter chips (e.g. anther_count)
+      if (typeof spVal === 'number' && spVal === Number(v)) { hit = true; break; }
     }
     if (hit) matched++;
   }
@@ -608,6 +665,25 @@ function renderRow(sp, filters) {
     sp.stoloniferous ? '<span class="pill pill-habit">Stoloniferous</span>' : '',
   ].filter(Boolean).join(' ') || na();
 
+  const COMPRESSION_LABELS = { lateral: 'Lateral', dorsiventral: 'Dorsiventral' };
+  const compression = sp.spikelet_compression ? COMPRESSION_LABELS[sp.spikelet_compression] || sp.spikelet_compression : na();
+
+  const spikeLen = sp.spikelet_length_mm_min != null
+    ? `${sp.spikelet_length_mm_min}–${sp.spikelet_length_mm_max} mm`
+    : na();
+
+  const anthers = sp.anther_count != null ? String(sp.anther_count) : na();
+
+  const LEMMA_LABELS = { glabrous: 'Glabrous', pubescent: 'Pubescent', scabrous: 'Scabrous', hairy: 'Hairy' };
+  const lemmaSurf = sp.lemma_surface ? (LEMMA_LABELS[sp.lemma_surface] || sp.lemma_surface) : na();
+
+  const BLADE_LABELS = { flat: 'Flat', involute: 'Involute', flat_or_involute: 'Flat/involute', folded: 'Folded', convolute: 'Convolute' };
+  const bladeShape = sp.leaf_blade_shape ? (BLADE_LABELS[sp.leaf_blade_shape] || sp.leaf_blade_shape) : na();
+
+  const auricles = sp.auricles === true ? '<span class="pill pill-yes">Present</span>'
+    : sp.auricles === false ? '<span class="pill pill-no">Absent</span>'
+    : na();
+
   const photoEl = sp.photo_url
     ? `<img class="sp-photo" src="${sp.photo_url}" alt="${sp.sci_name}" loading="lazy" data-medium="${sp.photo_medium || sp.photo_url}">`
     : `<div class="sp-photo-placeholder"></div>`;
@@ -637,6 +713,12 @@ function renderRow(sp, filters) {
     <td>${lw}</td>
     <td>${ht}</td>
     <td>${habitPills}</td>
+    <td>${compression}</td>
+    <td>${spikeLen}</td>
+    <td>${anthers}</td>
+    <td>${lemmaSurf}</td>
+    <td>${bladeShape}</td>
+    <td>${auricles}</td>
     <td>${sp.inat_obs_sf}</td>
   </tr>`;
 }


### PR DESCRIPTION
## Summary

- Awn length, leaf width, plant height, inflorescence, and florets/spikelet now support selecting multiple values — matching any selected value (OR logic)
- Single-select stays for mutually exclusive fields: duration, ligule, has awns, awn type, native/introduced
- Multi-select groups show a small "multi-select" label in the heading
- Scoring still counts each criterion as 1 regardless of how many values are selected for it

https://claude.ai/code/session_015FPkJ8HoXqsSh4WrAP5PtZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015FPkJ8HoXqsSh4WrAP5PtZ)_