### PR TITLE
SF Grass Identifier: move filter chips into match column

### DIFF
--- a/sf-grass-identifier/index.html
+++ b/sf-grass-identifier/index.html
@@ -182,10 +182,18 @@
     }
 
     td.match-cell {
-      min-width: 110px;
+      min-width: 140px;
       text-align: center;
       font-weight: 700;
       font-size: .85rem;
+      vertical-align: top;
+    }
+    .filter-breakdown {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 3px;
+      margin-top: 5px;
     }
 
     .match-pill {
@@ -283,15 +291,6 @@
       margin-left: 4px;
     }
 
-    /* ── Filter breakdown row ── */
-    .filter-result-row td {
-      padding: 3px 12px 7px 76px; /* indent past photo */
-      background: #f9f8f6;
-      border-bottom: 1px solid #f0ece4;
-    }
-    tbody tr.top-match + .filter-result-row td { background: #edfaf2; }
-    tbody tr.filter-result-row:hover { background: inherit; }
-    .filter-breakdown { display: flex; flex-wrap: wrap; gap: 4px; }
     .fchip {
       display: inline-flex;
       align-items: center;
@@ -686,13 +685,11 @@ const VALUE_LABELS = {
   '3-5': '3–5', '6-10': '6–10', '11+': '11+',
 };
 
-function filterBreakdownRow(sp, filters, isTopMatch) {
+function filterChips(sp, filters) {
   if (!Object.keys(filters).length) return '';
-  const colspan = 27;
   const chips = [];
 
   for (const [key, vals] of Object.entries(filters)) {
-    // mirror scoreSpecies logic
     let isVar = false;
     let matched = false;
     if (key === 'duration' && sp._durationBoth) {
@@ -711,16 +708,13 @@ function filterBreakdownRow(sp, filters, isTopMatch) {
     }
 
     const label = FILTER_LABELS[key] || key;
-    const valStr = [...vals].map(v => VALUE_LABELS[v] || v).join(' / ');
+    const valStr = [...vals].map(v => VALUE_LABELS[v] || v).join('/');
     const cls = isVar ? 'fchip fchip-var' : matched ? 'fchip fchip-match' : 'fchip fchip-miss';
     const icon = isVar ? '~' : matched ? '✓' : '✗';
-    chips.push(`<span class="${cls}">${label}: ${valStr} ${icon}</span>`);
+    chips.push(`<span class="${cls}">${label} ${icon}</span>`);
   }
 
-  const rowBg = isTopMatch ? 'top-match' : '';
-  return `<tr class="filter-result-row ${rowBg}">
-    <td colspan="${colspan}"><div class="filter-breakdown">${chips.join('')}</div></td>
-  </tr>`;
+  return `<div class="filter-breakdown">${chips.join('')}</div>`;
 }
 
 // ── Render ─────────────────────────────────────────────────────────────────
@@ -851,7 +845,7 @@ function renderRow(sp, filters) {
   const hist = histogramSVG(sp.inat_id);
 
   const mainRow = `<tr class="${rowClass}">
-    <td class="match-cell">${hasFilters ? matchPill(matched, total) : '<span class="no-data">—</span>'}</td>
+    <td class="match-cell">${hasFilters ? matchPill(matched, total) : '<span class="no-data">—</span>'}${hasFilters ? filterChips(sp, filters) : ''}</td>
     <td class="species-cell">
       <div class="species-inner">
         ${photoEl}
@@ -889,7 +883,7 @@ function renderRow(sp, filters) {
     <td>${liguLen}</td>
     <td>${sp.inat_obs_sf}</td>
   </tr>`;
-  return mainRow + filterBreakdownRow(sp, filters, isTopMatch);
+  return mainRow;
 }
 
 function render() {


### PR DESCRIPTION
Moves the per-filter match/miss chips from a second spanning row into the Match cell itself — stacked below the score pill. Cleaner layout, no extra row.

---
_Generated by [Claude Code](https://claude.ai/code/session_015FPkJ8HoXqsSh4WrAP5PtZ)_